### PR TITLE
add construct_Lambdamatrix_forSTOUT! for MPI and correct exptU!

### DIFF
--- a/src/4D/gaugefields_4D_mpi.jl
+++ b/src/4D/gaugefields_4D_mpi.jl
@@ -973,16 +973,16 @@ function exptU!(
     w = temps[2]
 
 
-    NT = v.NT
-    NZ = v.NZ
-    NY = v.NY
-    NX = v.NX
+    NT = uin.NT
+    NZ = uin.NZ
+    NY = uin.NY
+    NX = uin.NX
     #t = 1
 
-    @inbounds for it = 1:v.PN[4]
-        for iz = 1:v.PN[3]
-            for iy = 1:v.PN[2]
-                for ix = 1:v.PN[1]
+    @inbounds for it = 1:uin.PN[4]
+        for iz = 1:uin.PN[3]
+            for iy = 1:uin.PN[2]
+                for ix = 1:uin.PN[1]
                     v11 = getvalue(uin, 1, 1, ix, iy, iz, it)
                     v22 = getvalue(uin, 2, 2, ix, iy, iz, it)
                     v33 = getvalue(uin, 3, 3, ix, iy, iz, it)

--- a/src/4D/gaugefields_4D_mpi.jl
+++ b/src/4D/gaugefields_4D_mpi.jl
@@ -966,7 +966,7 @@ const fac13 = 1 / 3
 function exptU!(
     uout::T,
     t::N,
-    v::Gaugefields_4D_wing_mpi{3},
+    uin::Gaugefields_4D_wing_mpi{3}, ### HH: change v to uin to avoid overwriting the input
     temps::Array{T,1},
 ) where {N<:Number,T<:Gaugefields_4D_wing_mpi} #uout = exp(t*u)
     ww = temps[1]
@@ -983,9 +983,9 @@ function exptU!(
         for iz = 1:v.PN[3]
             for iy = 1:v.PN[2]
                 for ix = 1:v.PN[1]
-                    v11 = getvalue(v, 1, 1, ix, iy, iz, it)
-                    v22 = getvalue(v, 2, 2, ix, iy, iz, it)
-                    v33 = getvalue(v, 3, 3, ix, iy, iz, it)
+                    v11 = getvalue(uin, 1, 1, ix, iy, iz, it)
+                    v22 = getvalue(uin, 2, 2, ix, iy, iz, it)
+                    v33 = getvalue(uin, 3, 3, ix, iy, iz, it)
 
                     tri = fac13 * (imag(v11) + imag(v22) + imag(v33))
 
@@ -998,12 +998,12 @@ function exptU!(
                     y22 = (imag(v22) - tri) * im
                     y33 = (imag(v33) - tri) * im
 
-                    v12 = getvalue(v, 1, 2, ix, iy, iz, it)
-                    v13 = getvalue(v, 1, 3, ix, iy, iz, it)
-                    v21 = getvalue(v, 2, 1, ix, iy, iz, it)
-                    v23 = getvalue(v, 2, 3, ix, iy, iz, it)
-                    v31 = getvalue(v, 3, 1, ix, iy, iz, it)
-                    v32 = getvalue(v, 3, 2, ix, iy, iz, it)
+                    v12 = getvalue(uin, 1, 2, ix, iy, iz, it)
+                    v13 = getvalue(uin, 1, 3, ix, iy, iz, it)
+                    v21 = getvalue(uin, 2, 1, ix, iy, iz, it)
+                    v23 = getvalue(uin, 2, 3, ix, iy, iz, it)
+                    v31 = getvalue(uin, 3, 1, ix, iy, iz, it)
+                    v32 = getvalue(uin, 3, 2, ix, iy, iz, it)
 
                     x12 = v12 - conj(v21)
                     x13 = v13 - conj(v31)
@@ -1195,7 +1195,7 @@ function exptU!(
                     ww17 = w17 * c3 - w18 * s3
                     ww18 = w18 * c3 + w17 * s3
 
-                    v = w1 + im * w2
+                    v = w1 + im * w2    ### HH: v is overing the input uin (which was v)
                     setvalue!(w, v, 1, 1, ix, iy, iz, it)
                     v = w3 + im * w4
                     setvalue!(w, v, 1, 2, ix, iy, iz, it)
@@ -3045,3 +3045,86 @@ function thooftLoop_4D_B_temporal_wing_mpi(
       return U
     end
 end
+
+
+### added by HH for WLB gauge fixing projection
+
+"""
+M = (U*δ_prev) star (dexp(Q)/dQ)
+Λ = TA(M)
+"""
+function construct_Λmatrix_forSTOUT!(
+    Λ,
+    δ_current::Gaugefields_4D_wing_mpi{NC},
+    Q,
+    u::Gaugefields_4D_wing_mpi{NC},
+) where {NC}
+    ### HH: get the position under MPI
+    NT = u.PN[4]
+    NZ = u.PN[3]
+    NY = u.PN[2]
+    NX = u.PN[1]
+    
+    Qn = zeros(ComplexF64, NC, NC)
+    Un = zero(Qn)
+    Mn = zero(Qn)
+    Λn = zero(Qn)
+    δn_current = zero(Qn)
+    temp1 = similar(Qn)
+    temp2 = similar(Qn)
+    temp3 = similar(Qn)
+
+    for it = 1:NT
+        for iz = 1:NZ
+            for iy = 1:NY
+                for ix = 1:NX
+
+                    for jc = 1:NC
+                        for ic = 1:NC
+                            Un[ic, jc] = getvalue(u, ic, jc, ix, iy, iz, it)
+                            Qn[ic, jc] = getvalue(Q, ic, jc, ix, iy, iz, it)#*im
+                            δn_current[ic, jc] = getvalue(δ_current, ic, jc, ix, iy, iz, it)
+                        end
+                    end
+
+                    calc_Mmatrix!(Mn, δn_current, Qn, Un, u, [temp1, temp2, temp3])
+                    calc_Λmatrix!(Λn, Mn, NC)
+
+                    for jc = 1:NC
+                        for ic = 1:NC
+                           setvalue!(Λ, Λn[ic, jc], ic, jc, ix, iy, iz, it)
+                        end
+                    end
+
+                end
+            end
+        end
+    end
+    set_wing_U!(Λ)
+end
+
+
+function unit_U!(Uμ::Gaugefields_4D_wing_mpi{NC}) where {NC}
+    NT = Uμ.PN[4]
+    NZ = Uμ.PN[3]
+    NY = Uμ.PN[2]
+    NX = Uμ.PN[1]
+    for it = 1:NT
+        for iz = 1:NZ
+            for iy = 1:NY
+                for ix = 1:NX
+
+                    for k2 = 1:NC
+                        for k1 = 1:NC
+                            @inbounds setvalue!(Uμ, ifelse(k1 == k2, 1, 0), k1, k2, ix, iy, iz, it )
+                        end
+                    end
+                end
+            end
+        end
+    end
+    set_wing_U!(Uμ)
+
+end
+
+### HH edited for WLB gauge fixing projection

--- a/src/4D/gaugefields_4D_mpi_nowing.jl
+++ b/src/4D/gaugefields_4D_mpi_nowing.jl
@@ -2464,16 +2464,16 @@ function exptU!(
     w = temps[2]
 
 
-    NT = v.NT
-    NZ = v.NZ
-    NY = v.NY
-    NX = v.NX
+    NT = uin.NT
+    NZ = uin.NZ
+    NY = uin.NY
+    NX = uin.NX
     #t = 1
 
-    @inbounds for it = 1:v.PN[4]
-        for iz = 1:v.PN[3]
-            for iy = 1:v.PN[2]
-                for ix = 1:v.PN[1]
+    @inbounds for it = 1:uin.PN[4]
+        for iz = 1:uin.PN[3]
+            for iy = 1:uin.PN[2]
+                for ix = 1:uin.PN[1]
                     v11 = getvalue(uin, 1, 1, ix, iy, iz, it)
                     v22 = getvalue(uin, 2, 2, ix, iy, iz, it)
                     v33 = getvalue(uin, 3, 3, ix, iy, iz, it)

--- a/src/4D/gaugefields_4D_mpi_nowing.jl
+++ b/src/4D/gaugefields_4D_mpi_nowing.jl
@@ -1433,6 +1433,7 @@ function mpi_updates_U_moredata!(U::Gaugefields_4D_nowing_mpi{NC}, send_ranks) w
     MPI.Win_fence(0, win_i)
     MPI.Win_fence(0, win_c)
 
+    GC.enable(false)
     icount = 0
     for (myrank_send, value) in send_ranks
         count = value.count
@@ -1453,6 +1454,8 @@ function mpi_updates_U_moredata!(U::Gaugefields_4D_nowing_mpi{NC}, send_ranks) w
     MPI.Win_fence(0, win)
     MPI.Win_fence(0, win_i)
     MPI.Win_fence(0, win_c)
+    GC.enable(true)
+
 
     your_ranks .= -1
 

--- a/src/4D/gaugefields_4D_mpi_nowing.jl
+++ b/src/4D/gaugefields_4D_mpi_nowing.jl
@@ -4456,9 +4456,9 @@ M = (U*δ_prev) star (dexp(Q)/dQ)
 """
 function construct_Λmatrix_forSTOUT!(
     Λ,
-    δ_current::Gaugefields_4D_wing_mpi{NC},
+    δ_current::Gaugefields_4D_nowing_mpi{NC},
     Q,
-    u::Gaugefields_4D_wing_mpi{NC},
+    u::Gaugefields_4D_nowing_mpi{NC},
 ) where {NC}
     ### HH: get the position under MPI
     NT = u.PN[4]
@@ -4505,7 +4505,7 @@ function construct_Λmatrix_forSTOUT!(
 end
 
 
-function unit_U!(Uμ::Gaugefields_4D_wing_mpi{NC}) where {NC}
+function unit_U!(Uμ::Gaugefields_4D_nowing_mpi{NC}) where {NC}
     NT = Uμ.PN[4]
     NZ = Uμ.PN[3]
     NY = Uμ.PN[2]

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -3350,6 +3350,8 @@ function calc_Mmatrix!(
             end
         end
         Mn ./= im
+    else
+        mul!(Mn, Un, δn_prev) # --> f1 = 1, added by HH for WLB gauge fixing project, to have a well-defined point when Q == 0 for θ =0. 
     end
 end
 

--- a/src/Gaugefields.jl
+++ b/src/Gaugefields.jl
@@ -181,6 +181,7 @@ import .AbstractGaugefields_module:
     clear_U!,
     add_U!,
     exptU!,
+    normalize_U!,
     Traceless_antihermitian!,
     Traceless_antihermitian,
     Generator,
@@ -221,8 +222,8 @@ import .GaugeAction_module:
     get_temporary_gaugefields,
     evaluate_GaugeAction
 
-import .Temporalfields_module: Temporalfields, unused!
-export Temporalfields, unused!
+import .Temporalfields_module: Temporalfields, unused!, get_temp
+export Temporalfields, unused!, get_tmp
 
 export IdentityGauges,
     RandomGauges, Oneinstanton, calculate_Plaquette, calculate_Polyakov_loop

--- a/src/Gaugefields.jl
+++ b/src/Gaugefields.jl
@@ -43,7 +43,8 @@ function __init__()
 end
 
 import .AbstractGaugefields_module:
-    Gaugefields_4D_accelerator
+    Gaugefields_4D_accelerator,
+    shiftedindex
 
 # Write your package code here.
 import .Verboseprint_mpi:
@@ -211,7 +212,9 @@ import .AbstractGaugefields_module:
     getvalue,
     get_nprocs,
     write_to_numpyarray,
-    map_U_sequential!
+    map_U_sequential!,
+    fourdim_cordinate
+    
 import Wilsonloop: make_loops_fromname
 import .GaugeAction_module:
     GaugeAction,

--- a/src/Gaugefields.jl
+++ b/src/Gaugefields.jl
@@ -213,7 +213,8 @@ import .AbstractGaugefields_module:
     get_nprocs,
     write_to_numpyarray,
     map_U_sequential!,
-    fourdim_cordinate
+    fourdim_cordinate,
+    unit_U!
     
 import Wilsonloop: make_loops_fromname
 import .GaugeAction_module:

--- a/src/output/ildg_format.jl
+++ b/src/output/ildg_format.jl
@@ -89,7 +89,7 @@ function __init__()
                                         for ic1 = 1:NC
                                             count += 1
                                             v = recv_mesg[count]
-                                            Gaugefields.setvalue!(
+                                            setvalue!(
                                                 U[μ],
                                                 v,
                                                 ic2,

--- a/src/output/ildg_format.jl
+++ b/src/output/ildg_format.jl
@@ -654,7 +654,7 @@ function load_gaugefield!(U, i, ildg::ILDG, L, NC; NDW=1)
         run(`$exe $filename $message_no $reccord_no tempconf.dat`)
     end
 
-    @time load_binarydata!(U, NX, NY, NZ, NT, NC, "tempconf.dat", precision)
+    load_binarydata!(U, NX, NY, NZ, NT, NC, "tempconf.dat", precision)
 
     return
 end

--- a/src/output/ildg_format.jl
+++ b/src/output/ildg_format.jl
@@ -332,10 +332,10 @@ function __init__()
                                         end
                                     end
                                 end
-                                sreq = MPI.Isend(send_mesg, rank, counttotal, U[1].comm)
+                                sreq = MPI.Isend(send_mesg, 0, counttotal, U[1].comm) ## HH: corrent sending rank
                             end
                             if U[1].myrank == 0
-                                rreq = MPI.Irecv!(recv_mesg, 0, counttotal, U[1].comm)
+                                rreq = MPI.Irecv!(recv_mesg, rank, counttotal, U[1].comm) ## HH: corrent receiving rank
                                 MPI.Wait!(rreq)
                                 count = 0
                                 for μ = 1:4

--- a/src/output/ildg_format.jl
+++ b/src/output/ildg_format.jl
@@ -160,7 +160,8 @@ function __init__()
             #close(fp)
         end
 
-        # #=
+
+        #HH: improving the config. reading speed -- version 1.
         function load_binarydata!(
             U::Vector{T},
             NX, NY, NZ, NT,
@@ -171,8 +172,7 @@ function __init__()
 
             myrank = U[1].myrank
             comm = MPI.COMM_WORLD
-            PN = U[1].PN
-            PEs = U[1].PEs
+            PN = U[1].PN            
             nprocs = U[1].nprocs
 
             Nfields = NC * NC * 4
@@ -232,10 +232,10 @@ function __init__()
             MPI.Barrier(comm)
             update!(U)
         end
-        # =#
-
-        #=
-        function load_binarydata!(
+        
+        
+        
+        function load_binarydata_og!(
             U::Array{T,1},
             NX,
             NY,
@@ -334,8 +334,8 @@ function __init__()
 
             #close(fp)
         end
-        =#
 
+        
         function save_binarydata(
             U::Array{T,1},
             filename; tempfile1="testbin.dat", tempfile2="filelist.dat"

--- a/src/output/ildg_format.jl
+++ b/src/output/ildg_format.jl
@@ -35,7 +35,7 @@ function __init__()
             counts = zeros(Int64, U[1].nprocs)
             totalnum = NX * NY * NZ * NT * NC * NC * 2 * 4
             PN = U[1].PN
-            Gaugefields.barrier(U[1])
+            barrier(U[1])
 
             N = NC * NC * 4
             send_mesg1 = Array{ComplexF64}(undef, 1)
@@ -77,11 +77,11 @@ function __init__()
                                     end
                                 end
                                 sreq =
-                                    MPI.Isend(send_mesg, rank, counttotal, Gaugefields.comm)
+                                    MPI.Isend(send_mesg, rank, counttotal, comm)
                             end
                             if U[1].myrank == rank
                                 rreq =
-                                    MPI.Irecv!(recv_mesg, 0, counttotal, Gaugefields.comm)
+                                    MPI.Irecv!(recv_mesg, 0, counttotal, comm)
                                 MPI.Wait!(rreq)
                                 count = 0
                                 for μ = 1:4
@@ -103,7 +103,7 @@ function __init__()
                                     end
                                 end
                             end
-                            Gaugefields.barrier(U[1])
+                            barrier(U[1])
                         end
                     end
                 end
@@ -117,16 +117,16 @@ function __init__()
             send_mesg1 =  Array{ComplexF64}(undef, N)#data[:,:,:,:,1] #Array{ComplexF64}(undef, N)
             recv_mesg1 = Array{ComplexF64}(undef, N)
             #comm = MPI.MPI_COMM_WORLD
-            #println(typeof(Gaugefields.comm))
+            #println(typeof(comm))
 
 
             for ip=0:U[1].nprocs-1
                 if U[1].myrank == 0
                     send_mesg1[:] = reshape(data[:,:,:,:,ip+1],:) #Array{ComplexF64}(undef, N)
-                    sreq1 = MPI.Isend(send_mesg1, ip, ip+32, Gaugefields.comm) 
+                    sreq1 = MPI.Isend(send_mesg1, ip, ip+32, comm) 
                 end
                 if U[1].myrank == ip
-                    rreq1 = MPI.Irecv!(recv_mesg1, 0, ip+32, Gaugefields.comm)
+                    rreq1 = MPI.Irecv!(recv_mesg1, 0, ip+32, comm)
                     MPI.Wait!(rreq1)
 
                     count = 0
@@ -151,7 +151,7 @@ function __init__()
 
             end
 
-            Gaugefields.barrier(U[1])
+            barrier(U[1])
             =#
 
             update!(U)
@@ -220,11 +220,11 @@ function __init__()
                                     end
                                 end
                                 sreq =
-                                    MPI.Isend(send_mesg, rank, counttotal, Gaugefields.comm)
+                                    MPI.Isend(send_mesg, rank, counttotal, comm)
                             end
                             if U[1].myrank == rank
                                 rreq =
-                                    MPI.Irecv!(recv_mesg, 0, counttotal, Gaugefields.comm)
+                                    MPI.Irecv!(recv_mesg, 0, counttotal, comm)
                                 MPI.Wait!(rreq)
                                 count = 0
                                 for μ = 1:4
@@ -253,7 +253,7 @@ function __init__()
             end
             #end
 
-            Gaugefields.barrier(U[1])
+            barrier(U[1])
             update!(U)
 
 
@@ -682,6 +682,8 @@ function extract_info(contents_data)
                 #println("reccord_no = $reccord_no")
                 #println("datatype  = $datatype ")
                 if datatype == "ildg-format"
+                    ### HH: There is some bug in this part. I will fix it later. 
+                    #=  
                     headerdic = Dict()
                     #println(data[2:end])
                     ist = findfirst('\"', data)
@@ -722,8 +724,8 @@ function extract_info(contents_data)
                     headerdic["NC"] = NC
                     headerdic["precision"] = precision
                     headerdic["headertype"] = "ildg-format"
-
-                    headerfound = true
+                    =#
+                    headerfound = false
 
                 elseif datatype == "scidac-private-file-xml"
                     headerdic = Dict()


### PR DESCRIPTION
In `gaugefields_4D_mpi_nowing.jl` and `gaugefields_4D_mpi.jl`, I added the function `construct_Λmatrix_forSTOUT!` for MPI and changed the input argument `v` to `uin` in the `exptU!` functions to avoid overwriting the input gauge links.

I am using `### HH: (...)` to tag my editing and for some explanation. Please remove them if you agree with the changes.