### PR TITLE
Strage for evaluations of external B fields

### DIFF
--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -1105,7 +1105,7 @@ function evaluate_gaugelinks!(
     temps::Array{T,1}, # length >= 4
 ) where {Dim,WL<:Wilsonline{Dim},T<:AbstractGaugefields}
     num = length(w)
-    temp4 = temps[4]
+    temp4 = temps[end]
 
     #ix,iy,iz,it=(2,2,2,2)
     #ix,iy,iz,it=(1,1,1,1)
@@ -1113,7 +1113,7 @@ function evaluate_gaugelinks!(
     clear_U!(xout)
     for i = 1:num
         glinks = w[i]
-        evaluate_gaugelinks!(temp4, glinks, U, temps[1:3]) # length >= 3
+        evaluate_gaugelinks!(temp4, glinks, U, temps[1:end-1]) # length >= 3
         #println("uout2 ", temp2[:,:,ix,iy,iz,it])
         add_U!(xout, temp4)
         #println("xout ", xout[:,:,ix,iy,iz,it])

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -25,7 +25,7 @@ import ..Verboseprint_mpi:
 using InteractiveUtils
 
 import ..Temporalfields_module: Temporalfields, unused!, get_temp
-
+import ..Storedlinkfields_module: Storedlinkfields, is_storedlink, store_link!, get_storedlink
 
 abstract type Abstractfields end
 

--- a/src/AbstractGaugefields_Bfields.jl
+++ b/src/AbstractGaugefields_Bfields.jl
@@ -972,12 +972,12 @@ function evaluate_gaugelinks!(
     temps::Array{T,1}, # length >= 5+3
 ) where {Dim,WL<:Wilsonline{Dim},T<:AbstractGaugefields}
     num = length(w)
-    temp1 = temps[8]
+    temp1 = temps[end]
 
     clear_U!(xout)
     for i = 1:num
         glinks = w[i]
-        evaluate_gaugelinks!(temp1, glinks, U, B, temps[1:7]) # length >= 4+3
+        evaluate_gaugelinks!(temp1, glinks, U, B, temps[1:end-1]) # length >= 4+3
         add_U!(xout, temp1)
     end
 
@@ -992,12 +992,12 @@ function evaluate_gaugelinks!(
     temps::Array{T,1}, # length >= 5+3 + 2
 ) where {Dim,WL<:Wilsonline{Dim},T<:AbstractGaugefields,Pz<:Storedlinkfields}
     num = length(w)
-    temp1 = temps[10]
+    temp1 = temps[end]
 
     clear_U!(xout)
     for i = 1:num
         glinks = w[i]
-        evaluate_gaugelinks!(temp1, glinks, U, B, Bps, temps[1:9]) # length >= 4+3 + 2
+        evaluate_gaugelinks!(temp1, glinks, U, B, Bps, temps[1:end-1]) # length >= 4+3 + 2
         add_U!(xout, temp1)
     end
 

--- a/src/Gaugefields.jl
+++ b/src/Gaugefields.jl
@@ -2,6 +2,7 @@ module Gaugefields
 
 using Requires
 include("./Temporalfields/temporalfields.jl")
+include("./Storedlinkfields/storedlinkfields.jl")
 include("./output/verboseprint_mpi.jl")
 #include("./output/verboseprint.jl")
 include("./SUN_generator.jl")

--- a/src/Gaugefields.jl
+++ b/src/Gaugefields.jl
@@ -154,7 +154,7 @@ import .Abstractsmearing_module:
     zero_grad!,
     get_parameters
 import .SUN_generator: Generator
-import .Gradientflow_module: Gradientflow, Gradientflow_general, flow!, get_tempG, get_eps
+import .Gradientflow_module: Gradientflow, Gradientflow_general, Gradientflow_general_Bfields, Gradientflow_general_Bfields_bg, flow!, get_tempG, get_eps
 #import .Verbose_print:Verbose_level,Verbose_3,Verbose_2,Verbose_1,println_verbose3,println_verbose2,println_verbose1,
 #    print_verbose1,print_verbose2,print_verbose3
 
@@ -255,7 +255,7 @@ export set_parameters!, get_parameter_derivatives, apply_smearing_U,
     zero_grad!,
     get_parameters
 export construct_Adjoint_rep_Gaugefields
-export get_myrank, getvalue, get_nprocs, Gradientflow_general
+export get_myrank, getvalue, get_nprocs, Gradientflow_general, Gradientflow_general_Bfields, Gradientflow_general_Bfields_bg
 export Heatbath_update
 export println_verbose_level1, println_verbose_level2, println_verbose_level3
 export overrelaxation!

--- a/src/Gaugefields.jl
+++ b/src/Gaugefields.jl
@@ -223,7 +223,9 @@ import .GaugeAction_module:
     evaluate_GaugeAction
 
 import .Temporalfields_module: Temporalfields, unused!
+import .Storedlinkfields_module: Storedlinkfields, is_storedlink, store_link!, get_storedlink
 export Temporalfields, unused!
+export Storedlinkfields, is_storedlink, store_link!, get_storedlink
 
 export IdentityGauges,
     RandomGauges, Oneinstanton, calculate_Plaquette, calculate_Polyakov_loop

--- a/src/Storedlinkfields/storedlinkfields.jl
+++ b/src/Storedlinkfields/storedlinkfields.jl
@@ -1,0 +1,148 @@
+module Storedlinkfields_module
+
+import Wilsonloop: Wilsonline
+
+mutable struct Storedlinkfields{TG,WL<:Wilsonline}
+    _data::Vector{TG}
+    _link::Vector{WL}
+    _flagusing::Vector{Bool}
+    _indices::Vector{Int64}
+    Nmax::Int64
+
+    function Storedlinkfields(a::TG, l::WL; num=1, Nmax=1000) where {TG,WL<:Wilsonline}
+        _data = Vector{TG}(undef, num)
+        _link = Vector{WL}(undef, num)
+        _flagusing = zeros(Bool, num)
+        _indices = zeros(Int64, num)
+        similar_l = Wilsonline([])
+        for i = 1:num
+            _data[i] = similar(a)
+            _link[i] = similar_l
+        end
+        return new{TG,WL}(_data, _link, _flagusing, _indices, Nmax)
+    end
+
+    function Storedlinkfields(_data::Vector{TG}, _link::Vector{WL}, _flagusing, _indices, Nmax) where {TG,WL<:Wilsonline}
+        return new{TG,WL}(_data, _link, _flagusing, _indices, Nmax)
+    end
+
+end
+
+function Storedlinkfields_fromvector(a::Vector{TG}, l::Vector{WL}; Nmax=1000) where {TG,WL<:Wilsonline}
+    num = length(a)
+    if num != length(l)
+        error("Lengths of TG and WL vectors are mismatched.")
+    end
+    _flagusing = zeros(Bool, num)
+    _indices = zeros(Int64, num)
+    return Storedlinkfields(a, l, _flagusing, _indices, Nmax)
+end
+export Storedlinkfields_fromvector
+
+Base.eltype(::Type{Storedlinkfields{TG,WL}}) where {TG,WL} = TG
+
+Base.length(t::Storedlinkfields{TG,WL}) where {TG,WL} = length(t._data)
+
+Base.size(t::Storedlinkfields{TG,WL}) where {TG,WL} = size(t._data)
+
+function Base.firstindex(t::Storedlinkfields{TG,WL}) where {TG,WL}
+    return 1
+end
+
+function Base.lastindex(t::Storedlinkfields{TG,WL}) where {TG,WL}
+    return length(t._data)
+end
+
+function Base.getindex(t::Storedlinkfields{TG,WL}, i::Int) where {TG,WL}
+    @assert i <= length(t._data) "The length of the storedlinkfields is shorter than the index $i."
+    @assert i <= t.Nmax "The number of the storedlinkfields $i is larger than the maximum number $(Nmax). Change Nmax."
+    if t._indices[i] == 0
+        index = findfirst(x -> x == 0, t._flagusing)
+        t._flagusing[index] = true
+        t._indices[i] = index
+    end
+
+    return t._data[t._indices[i]], t._link[t._indices[i]]
+end
+
+function Base.getindex(t::Storedlinkfields{TG,WL}, I::Vararg{Int,N}) where {TG,WL,N}
+    data = TG[]
+    link = WL[]
+    for i in I
+        data_tmp, link_tmp = t[i]
+        push!(data, data_tmp)
+        push!(link, link_tmp)
+    end
+    return data, link
+end
+
+function Base.getindex(t::Storedlinkfields{TG,WL}, I::AbstractVector{T}) where {TG,WL,T<:Integer}
+    data = TG[]
+    link = WL[]
+    for i in I
+        data_tmp, link_tmp = t[i]
+        push!(data, data_tmp)
+        push!(link, link_tmp)
+    end
+    return data, link
+end
+
+function Base.display(t::Storedlinkfields{TG,WL}) where {TG,WL}
+    n = length(t._data)
+    println("The strage size of fields: $n")
+    numused = sum(t._flagusing)
+    println("The total number of fields used: $numused")
+    for i = 1:n
+        if t._indices[i] != 0
+            println("The address $(t._indices[i]) is used as the index $i")
+        end
+    end
+    println("The flags: $(t._flagusing)")
+    println("The indices: $(t._indices)")
+end
+
+function is_storedlink(t::Storedlinkfields{TG,WL}, l::WL) where {TG,WL}
+    if l in t._link
+        return true
+    else
+        return false
+    end
+end
+
+function store_link!(t::Storedlinkfields{TG,WL}, a::TG, l::WL) where {TG,WL}
+    n = length(t._data)
+    i = findfirst(x -> x == 0, t._indices)
+    if i == nothing
+        error("All strage of $n fields are used.")
+    end
+    index = i
+    if !is_storedlink(t,l)
+        t._flagusing[index] = true
+        t._indices[i] = index
+        t._data[index] = deepcopy(a)
+        t._link[index] = deepcopy(l)
+    end
+end
+
+function store_link!(t::Storedlinkfields{TG,WL}, as::Vector{TG}, ls::Vector{WL}) where {TG,WL}
+    n = length(as)
+    if n != length(ls)
+        error("Lengths of TG and WL vectors are mismatched.")
+    end
+    for i = 1:n
+        store_link!(t, as[i], ls[i])
+    end
+end
+
+function get_storedlink(t::Storedlinkfields{TG,WL}, l::WL) where {TG,WL}
+    i = findfirst(x -> x == l, t._link)
+    if i == nothing
+        error("No such a stored link.")
+    end
+    index = t._indices[i]
+    return t._data[index]
+end
+
+export Storedlinkfields, is_storedlink, store_link!, get_storedlink
+
+end

--- a/src/action/GaugeActions.jl
+++ b/src/action/GaugeActions.jl
@@ -14,7 +14,7 @@ using LinearAlgebra
 using InteractiveUtils
 
 import ..Temporalfields_module: Temporalfields, unused!, get_temp, set_reusemode!
-
+import ..Storedlinkfields_module: Storedlinkfields, is_storedlink, store_link!, get_storedlink
 
 
 struct GaugeAction_dataset{Dim}

--- a/src/action/GaugeActions_Bfields.jl
+++ b/src/action/GaugeActions_Bfields.jl
@@ -8,6 +8,17 @@ function calc_dSdUμ(
     calc_dSdUμ!(dSdUμ, S, μ, U, B)
     return dSdUμ
 end
+function calc_dSdUμ(
+    S::GaugeAction,
+    μ,
+    U::Vector{T},
+    B::Array{T,2},
+    Bps::Pz,
+) where {Dim,NC,T<:AbstractGaugefields{NC,Dim},Pz<:Storedlinkfields}
+    dSdUμ = similar(U[1])
+    calc_dSdUμ!(dSdUμ, S, μ, U, B, Bps)
+    return dSdUμ
+end
 
 function calc_dSdUμ!(
     dSdUμ::T, # dSdUμ -> S._temp_U[end] or other-temp
@@ -36,6 +47,32 @@ function calc_dSdUμ!(
     unused!(S._temp_U, its_temps)
 
 end
+function calc_dSdUμ!(
+    dSdUμ::T,
+    S::GaugeAction,
+    μ,
+    U::Vector{T},
+    B::Array{T,2},
+    Bps::Pz,
+) where {Dim,NC,T<:AbstractGaugefields{NC,Dim},Pz<:Storedlinkfields}
+    temp,  it_temp   = get_temp(S._temp_U)
+    temps, its_temps = get_temp(S._temp_U, 10)
+    numterm = length(S.dataset)
+
+    clear_U!(dSdUμ)
+    for i = 1:numterm
+        dataset = S.dataset[i]
+        β = dataset.β
+        staples_μ = dataset.staples[μ]
+        evaluate_gaugelinks!(temp, staples_μ, U, B, Bps, temps)
+
+        add_U!(dSdUμ, β, temp)
+    end
+    set_wing_U!(dSdUμ)
+    unused!(S._temp_U, it_temp)
+    unused!(S._temp_U, its_temps)
+
+end
 
 function evaluate_GaugeAction(
     S::GaugeAction,
@@ -45,6 +82,18 @@ function evaluate_GaugeAction(
     temp1, it_temp1 = get_temp(S._temp_U)
     #temp1 = S._temp_U[end]
     evaluate_GaugeAction_untraced!(temp1, S, U, B)
+    value = tr(temp1)
+    unused!(S._temp_U, it_temp1)
+    return value
+end
+function evaluate_GaugeAction(
+    S::GaugeAction,
+    U::Vector{T},
+    B::Array{T,2},
+    Bps::Pz,
+) where {Dim,NC,T<:AbstractGaugefields{NC,Dim},Pz<:Storedlinkfields}
+    temp1, it_temp1 = get_temp(S._temp_U)
+    evaluate_GaugeAction_untraced!(temp1, S, U, B, Bps)
     value = tr(temp1)
     unused!(S._temp_U, it_temp1)
     return value
@@ -59,6 +108,19 @@ function evaluate_GaugeAction_untraced(
     clear_U!(uout)
 
     evaluate_GaugeAction_untraced!(uout, S, U, B)
+
+    return uout
+end
+function evaluate_GaugeAction_untraced(
+    S::GaugeAction,
+    U::Vector{T},
+    B::Array{T,2},
+    Bps::Pz,
+) where {Dim,NC,T<:AbstractGaugefields{NC,Dim},Pz<:Storedlinkfields}
+    uout = similar(U[1])
+    clear_U!(uout)
+
+    evaluate_GaugeAction_untraced!(uout, S, U, B, Bps)
 
     return uout
 end
@@ -88,6 +150,29 @@ function evaluate_GaugeAction_untraced!(
 
     return
 end
+function evaluate_GaugeAction_untraced!(
+    uout,
+    S::GaugeAction, # length(temps) > 9 + 2
+    U::Vector{T},
+    B::Array{T,2}
+) where {Dim,NC,T<:AbstractGaugefields{NC,Dim}}
+    numterm = length(S.dataset)
+    temp, it_temp = get_temp(S._temp_U)
+    temps, its_temps = get_temp(S._temp_U, 10)
+    clear_U!(uout)
+
+    for i = 1:numterm
+        dataset = S.dataset[i]
+        β = dataset.β
+        w = dataset.closedloops
+        evaluate_gaugelinks!(temp, w, U, B, Bps, temps)
+        add_U!(uout, β, temp)
+    end
+    set_wing_U!(uout)
+    unused!(S._temp_U, it_temp)
+    unused!(S._temp_U, its_temps)
+    return
+end
 
 function GaugeAction(
     U::Vector{T},
@@ -107,6 +192,24 @@ function GaugeAction(
     #for i = 1:num
     #    _temp_U[i] = similar(U[1])
     #end
+
+    return GaugeAction{Dim,eltype(U),eltype(dataset)}(hascovnet, covneuralnet, dataset, _temp_U)
+end
+function GaugeAction(
+    U::Vector{T},
+    B::Array{T,2},
+    Bps::Pz;
+    hascovnet=false,
+) where {NC,Dim,T<:AbstractGaugefields{NC,Dim},Pz<:Storedlinkfields}
+    if hascovnet
+        covneuralnet = CovNeuralnet(Dim=Dim)
+    else
+        covneuralnet = nothing
+    end
+    dataset = GaugeAction_dataset{Dim}[]
+
+    num = 14
+    _temp_U = Temporalfields(U[1]; num=num)
 
     return GaugeAction{Dim,eltype(U),eltype(dataset)}(hascovnet, covneuralnet, dataset, _temp_U)
 end

--- a/src/action/GaugeActions_Bfields.jl
+++ b/src/action/GaugeActions_Bfields.jl
@@ -154,8 +154,9 @@ function evaluate_GaugeAction_untraced!(
     uout,
     S::GaugeAction, # length(temps) > 9 + 2
     U::Vector{T},
-    B::Array{T,2}
-) where {Dim,NC,T<:AbstractGaugefields{NC,Dim}}
+    B::Array{T,2},
+    Bps::Pz,
+) where {Dim,NC,T<:AbstractGaugefields{NC,Dim},Pz<:Storedlinkfields}
     numterm = length(S.dataset)
     temp, it_temp = get_temp(S._temp_U)
     temps, its_temps = get_temp(S._temp_U, 10)

--- a/src/smearing/gradientflow.jl
+++ b/src/smearing/gradientflow.jl
@@ -22,6 +22,7 @@ import Wilsonloop: make_loops_fromname, Wilsonline
 using LinearAlgebra
 import Wilsonloop: LinearAlgebra.adjoint
 import ..Temporalfields_module: Temporalfields, unused!, get_temp
+import ..Storedlinkfields_module: Storedlinkfields, is_storedlink, store_link!, get_storedlink
 
 
 struct Gradientflow_general{Dim,TA,T} <: Abstractsmearing


### PR DESCRIPTION
I added Storedlinkfields_module for storing many results of evaluate_gaugelinks!, as a function of B. If B fields are external (fixed numbers), the original one, evaluate_gaugelinks! : (Wilsonloop, U_\mu, B_\mu\nu) -> U, is redundant because the evaluations for some plaquettes of B are identical at any time.

This is quite useful as follows:
Introducing the strage,
    piazza = Storedlinkfields(U[1], num=150)
then,
    gauge_action = GaugeAction(U,B,piazza)
and also
    Gradientflow_general_Bfields_bg
provides a good example.