### PR TITLE
Add SU(Nc) matrix embedding helper

### DIFF
--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -851,6 +851,37 @@ function Oneinstanton(NC, NDW, NN...; mpi=false, PEs=nothing, mpiinit=nothing)
     return U
 end
 
+function _validate_su2_embedding_block(NC, block)
+    NC isa Integer || throw(ArgumentError("NC must be an integer"))
+    NC >= 2 || throw(ArgumentError("NC must be at least 2"))
+    length(block) == 2 || throw(ArgumentError("block must contain two color indices"))
+
+    i, j = block
+    i isa Integer || throw(ArgumentError("block indices must be integers"))
+    j isa Integer || throw(ArgumentError("block indices must be integers"))
+    1 <= i < j <= NC || throw(ArgumentError("block must satisfy 1 <= i < j <= NC"))
+
+    return (Int(i), Int(j))
+end
+
+function _embed_su2_matrix_in_sun!(U, u2, block)
+    size(u2) == (2, 2) || throw(ArgumentError("u2 must be a 2 by 2 matrix"))
+    NC, NC2 = size(U)
+    NC == NC2 || throw(ArgumentError("U must be a square matrix"))
+    i, j = _validate_su2_embedding_block(NC, block)
+
+    fill!(U, zero(eltype(U)))
+    for c = 1:NC
+        U[c, c] = one(eltype(U))
+    end
+
+    U[i, i] = u2[1, 1]
+    U[i, j] = u2[1, 2]
+    U[j, i] = u2[2, 1]
+    U[j, j] = u2[2, 2]
+    return U
+end
+
 function construct_gauges(NC, NDW, NN...; mpi=false, PEs=nothing, mpiinit=nothing)
     dim = length(NN)
     if mpi
@@ -2787,5 +2818,4 @@ end
 include("ND.jl")
 
 end
-
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,11 @@ end
     include("init.jl")
 end
 
+@testset "SUN embedded instanton helpers" begin
+    println("SUN embedded instanton helpers")
+    include("sun_embedded_instanton.jl")
+end
+
 
 
 @testset "HMC nowing" begin
@@ -114,7 +119,6 @@ end
 @testset "Gaugefields.jl" begin
     # Write your tests here.
 end
-
 
 
 

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -1,0 +1,61 @@
+using Gaugefields
+using Test
+using LinearAlgebra
+
+const AG = Gaugefields.AbstractGaugefields_module
+
+function sample_su2_matrix()
+    c = cos(0.37)
+    s = sin(0.37)
+    return ComplexF64[
+        c im*s
+        im*s c
+    ]
+end
+
+function check_su2_embedding(NC, block)
+    u2 = sample_su2_matrix()
+    U = fill(99.0 + 99.0im, NC, NC)
+
+    @test AG._embed_su2_matrix_in_sun!(U, u2, block) === U
+    i, j = block
+    spectator = setdiff(1:NC, block)
+
+    @test U[i, i] == u2[1, 1]
+    @test U[i, j] == u2[1, 2]
+    @test U[j, i] == u2[2, 1]
+    @test U[j, j] == u2[2, 2]
+
+    for c in spectator
+        @test U[c, c] == 1
+        for d = 1:NC
+            if d != c
+                @test U[c, d] == 0
+                @test U[d, c] == 0
+            end
+        end
+    end
+
+    @test U' * U ≈ Matrix{ComplexF64}(I, NC, NC)
+    @test det(U) ≈ 1
+end
+
+@testset "SU(2) matrix embedding into SU(Nc)" begin
+    @test AG._validate_su2_embedding_block(3, (1, 2)) == (1, 2)
+    @test AG._validate_su2_embedding_block(4, [2, 4]) == (2, 4)
+
+    check_su2_embedding(3, (1, 2))
+    check_su2_embedding(3, (1, 3))
+    check_su2_embedding(3, (2, 3))
+    check_su2_embedding(4, (2, 4))
+    check_su2_embedding(5, (2, 5))
+
+    @test_throws ArgumentError AG._validate_su2_embedding_block(1, (1, 2))
+    @test_throws ArgumentError AG._validate_su2_embedding_block(3, (1, 1))
+    @test_throws ArgumentError AG._validate_su2_embedding_block(3, (0, 2))
+    @test_throws ArgumentError AG._validate_su2_embedding_block(3, (1, 4))
+    @test_throws ArgumentError AG._validate_su2_embedding_block(3, (2, 1))
+    @test_throws ArgumentError AG._validate_su2_embedding_block(3, (1, 2, 3))
+    @test_throws ArgumentError AG._embed_su2_matrix_in_sun!(zeros(3, 3), zeros(3, 3), (1, 2))
+    @test_throws ArgumentError AG._embed_su2_matrix_in_sun!(zeros(3, 2), sample_su2_matrix(), (1, 2))
+end


### PR DESCRIPTION
## Summary
- Add internal helpers to validate an SU(2) embedding block inside SU(Nc).
- Add an internal matrix helper that embeds a 2x2 SU(2) matrix into an SU(Nc) identity matrix.
- Add focused tests for SU(3), representative NC > 3 blocks, unitarity, determinant, spectator colors, and invalid blocks.

Stacked on #116.

## Tests
- `/Users/akio/.juliaup/bin/julia --project=. test/sun_embedded_instanton.jl`