### PR TITLE
Factor SU(2) instanton link helper

### DIFF
--- a/src/4D/nowing/gaugefields_4D_nowing.jl
+++ b/src/4D/nowing/gaugefields_4D_nowing.jl
@@ -327,25 +327,6 @@ function Oneinstanton_4D_nowing(NC, NX, NY, NZ, NT; verbose_level=2)
 
     println("# Starting from a instanton backgorund with radius R=$R ")
     inst_cent = [L[1] / 2 + 0.5, L[2] / 2 + 0.5, L[3] / 2 + 0.5, L[4] / 2 + 0.5]
-    #eps = 1/10000000
-    s1 = [
-        0.0 1.0
-        1.0 0.0
-    ]
-    s2 = [
-        0.0 -im*1.0
-        im*1.0 0.0
-    ]
-    s3 = [
-        1.0 0.0
-        0.0 -1.0
-    ]
-    En = [
-        1.0 0.0
-        0.0 1.0
-    ]
-    ss = [im * s1, im * s2, im * s3, En]
-    sd = [-im * s1, -im * s2, -im * s3, En]
     nn = 0
 
     for it = 1:NT
@@ -353,19 +334,8 @@ function Oneinstanton_4D_nowing(NC, NX, NY, NZ, NT; verbose_level=2)
             for iy = 1:NY
                 for ix = 1:NX
                     nn += 0
-                    nv = [ix - 1, iy - 1, iz - 1, it - 1] - inst_cent
-                    n2 = nv ⋅ nv
                     for mu = 1:4
-                        tau = [
-                            0 0
-                            0 0
-                        ]
-                        for nu = 1:4
-                            smunu = sd[mu] * ss[nu] - sd[nu] * ss[mu]
-                            tau += smunu * nv[nu]
-                        end
-                        sq = sqrt(n2 + R^2)
-                        tau = exp(im * tau * (1 / 2) * (1 / (n2)) * (im * R^2 / (n2 + R^2))) #1b
+                        tau = _su2_instanton_link(mu, ix, iy, iz, it, L; center=inst_cent, radius=R)
                         for j = 1:2
                             for i = 1:2
                                 U[mu][i, j, ix, iy, iz, it] = tau[i, j]

--- a/src/4D/wing/gaugefields_4D_wing.jl
+++ b/src/4D/wing/gaugefields_4D_wing.jl
@@ -400,25 +400,6 @@ function Oneinstanton_4D_wing(NC, NX, NY, NZ, NT, NDW; verbose_level=2)
 
     println("# Starting from a instanton backgorund with radius R=$R ")
     inst_cent = [L[1] / 2 + 0.5, L[2] / 2 + 0.5, L[3] / 2 + 0.5, L[4] / 2 + 0.5]
-    #eps = 1/10000000
-    s1 = [
-        0.0 1.0
-        1.0 0.0
-    ]
-    s2 = [
-        0.0 -im*1.0
-        im*1.0 0.0
-    ]
-    s3 = [
-        1.0 0.0
-        0.0 -1.0
-    ]
-    En = [
-        1.0 0.0
-        0.0 1.0
-    ]
-    ss = [im * s1, im * s2, im * s3, En]
-    sd = [-im * s1, -im * s2, -im * s3, En]
     nn = 0
 
     for it = 1:NT
@@ -426,19 +407,8 @@ function Oneinstanton_4D_wing(NC, NX, NY, NZ, NT, NDW; verbose_level=2)
             for iy = 1:NY
                 for ix = 1:NX
                     nn += 0
-                    nv = [ix - 1, iy - 1, iz - 1, it - 1] - inst_cent
-                    n2 = nv ⋅ nv
                     for mu = 1:4
-                        tau = [
-                            0 0
-                            0 0
-                        ]
-                        for nu = 1:4
-                            smunu = sd[mu] * ss[nu] - sd[nu] * ss[mu]
-                            tau += smunu * nv[nu]
-                        end
-                        sq = sqrt(n2 + R^2)
-                        tau = exp(im * tau * (1 / 2) * (1 / (n2)) * (im * R^2 / (n2 + R^2))) #1b
+                        tau = _su2_instanton_link(mu, ix, iy, iz, it, L; center=inst_cent, radius=R)
                         for j = 1:2
                             for i = 1:2
                                 U[mu][i, j, ix, iy, iz, it] = tau[i, j]

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -882,6 +882,46 @@ function _embed_su2_matrix_in_sun!(U, u2, block)
     return U
 end
 
+function _su2_instanton_link(μ, ix, iy, iz, it, L; center=nothing, radius=nothing, sign=+1)
+    length(L) == 4 || throw(ArgumentError("L must contain four lattice extents"))
+    1 <= μ <= 4 || throw(ArgumentError("μ must be in 1:4"))
+    sign in (-1, +1) || throw(ArgumentError("sign must be +1 or -1"))
+
+    center === nothing && (center = (L[1] / 2 + 0.5, L[2] / 2 + 0.5, L[3] / 2 + 0.5, L[4] / 2 + 0.5))
+    length(center) == 4 || throw(ArgumentError("center must contain four coordinates"))
+    radius === nothing && (radius = div(L[1], 2))
+    radius > 0 || throw(ArgumentError("radius must be positive"))
+
+    s1 = ComplexF64[
+        0 1
+        1 0
+    ]
+    s2 = ComplexF64[
+        0 -im
+        im 0
+    ]
+    s3 = ComplexF64[
+        1 0
+        0 -1
+    ]
+    En = ComplexF64[
+        1 0
+        0 1
+    ]
+    ss = (im * s1, im * s2, im * s3, En)
+    sd = (-im * s1, -im * s2, -im * s3, En)
+
+    nv = ComplexF64[ix - 1 - center[1], iy - 1 - center[2], iz - 1 - center[3], it - 1 - center[4]]
+    n2 = real(nv ⋅ nv)
+    tau = zeros(ComplexF64, 2, 2)
+    for ν = 1:4
+        smunu = sd[μ] * ss[ν] - sd[ν] * ss[μ]
+        tau += smunu * nv[ν]
+    end
+
+    return exp(im * tau * (1 / 2) * (1 / n2) * (im * sign * radius^2 / (n2 + radius^2)))
+end
+
 function construct_gauges(NC, NDW, NN...; mpi=false, PEs=nothing, mpiinit=nothing)
     dim = length(NN)
     if mpi
@@ -2818,4 +2858,3 @@ end
 include("ND.jl")
 
 end
-

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -59,3 +59,39 @@ end
     @test_throws ArgumentError AG._embed_su2_matrix_in_sun!(zeros(3, 3), zeros(3, 3), (1, 2))
     @test_throws ArgumentError AG._embed_su2_matrix_in_sun!(zeros(3, 2), sample_su2_matrix(), (1, 2))
 end
+
+function check_su2_instanton_links(U)
+    L = (U[1].NX, U[1].NY, U[1].NZ, U[1].NT)
+    center = (L[1] / 2 + 0.5, L[2] / 2 + 0.5, L[3] / 2 + 0.5, L[4] / 2 + 0.5)
+    radius = div(L[1], 2)
+
+    for μ = 1:4
+        for it = 1:L[4], iz = 1:L[3], iy = 1:L[2], ix = 1:L[1]
+            link = AG._su2_instanton_link(μ, ix, iy, iz, it, L; center, radius)
+            measured = ComplexF64[
+                U[μ][1, 1, ix, iy, iz, it] U[μ][1, 2, ix, iy, iz, it]
+                U[μ][2, 1, ix, iy, iz, it] U[μ][2, 2, ix, iy, iz, it]
+            ]
+
+            @test measured ≈ link
+            @test link' * link ≈ Matrix{ComplexF64}(I, 2, 2)
+            @test det(link) ≈ 1
+        end
+    end
+end
+
+@testset "SU(2) instanton link helper" begin
+    check_su2_instanton_links(Oneinstanton(2, 0, 4, 4, 4, 4))
+    check_su2_instanton_links(Oneinstanton(2, 1, 4, 4, 4, 4))
+
+    L = (4, 4, 4, 4)
+    anti_link = AG._su2_instanton_link(1, 1, 1, 1, 1, L; sign=-1)
+    @test anti_link' * anti_link ≈ Matrix{ComplexF64}(I, 2, 2)
+    @test det(anti_link) ≈ 1
+
+    @test_throws ArgumentError AG._su2_instanton_link(0, 1, 1, 1, 1, L)
+    @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, (4, 4, 4))
+    @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; radius=0)
+    @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; sign=0)
+    @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; center=(1, 2, 3))
+end


### PR DESCRIPTION
## Summary
- Factor the duplicated 4D SU(2) instanton link construction into an internal helper.
- Keep existing `Oneinstanton` behavior unchanged while routing 4D wing/no-wing constructors through the helper.
- Add focused tests for helper/link agreement, unitarity, determinant, invalid parameters, and the anti-instanton sign path.

Stacked on #117, which is stacked on #116.

## Tests
- `/Users/akio/.juliaup/bin/julia --project=. test/sun_embedded_instanton.jl`
- `/Users/akio/.juliaup/bin/julia --project=. -e 'using Gaugefields, Test, Random; include("test/init.jl")'`