### PR TITLE
Add SU(Nc)-embedded instanton API

### DIFF
--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -922,6 +922,59 @@ function _su2_instanton_link(μ, ix, iy, iz, it, L; center=nothing, radius=nothi
     return exp(im * tau * (1 / 2) * (1 / n2) * (im * sign * radius^2 / (n2 + radius^2)))
 end
 
+function Oneinstanton_SUN_embedded(
+    NC,
+    NX,
+    NY,
+    NZ,
+    NT;
+    NDW=0,
+    center=(NX / 2 + 0.5, NY / 2 + 0.5, NZ / 2 + 0.5, NT / 2 + 0.5),
+    radius=div(NX, 2),
+    sign=+1,
+    block=(1, 2),
+    verbose_level=2,
+)
+    NDW isa Integer || throw(ArgumentError("NDW must be an integer"))
+    NDW >= 0 || throw(ArgumentError("NDW must be nonnegative"))
+    block = _validate_su2_embedding_block(NC, block)
+    L = (NX, NY, NZ, NT)
+
+    if NDW == 0
+        u = Gaugefields_4D_nowing(NC, NX, NY, NZ, NT, verbose_level=verbose_level)
+    else
+        u = Gaugefields_4D_wing(NC, NDW, NX, NY, NZ, NT, verbose_level=verbose_level)
+    end
+
+    U = Array{typeof(u),1}(undef, 4)
+    U[1] = u
+    for μ = 2:4
+        U[μ] = similar(u)
+    end
+
+    sunlink = zeros(ComplexF64, NC, NC)
+    for it = 1:NT
+        for iz = 1:NZ
+            for iy = 1:NY
+                for ix = 1:NX
+                    for μ = 1:4
+                        su2link = _su2_instanton_link(μ, ix, iy, iz, it, L; center, radius, sign)
+                        _embed_su2_matrix_in_sun!(sunlink, su2link, block)
+                        for j = 1:NC
+                            for i = 1:NC
+                                U[μ][i, j, ix, iy, iz, it] = sunlink[i, j]
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    set_wing_U!(U)
+    return U
+end
+
 function construct_gauges(NC, NDW, NN...; mpi=false, PEs=nothing, mpiinit=nothing)
     dim = length(NN)
     if mpi

--- a/src/Gaugefields.jl
+++ b/src/Gaugefields.jl
@@ -64,6 +64,7 @@ import .AbstractGaugefields_module:
     IdentityGauges,
     RandomGauges,
     Oneinstanton,
+    Oneinstanton_SUN_embedded,
     calculate_Plaquette,
     calculate_Polyakov_loop,
     map_U!,
@@ -210,6 +211,7 @@ import .AbstractGaugefields_module:
     IdentityGauges,
     RandomGauges,
     Oneinstanton,
+    Oneinstanton_SUN_embedded,
     Initialize_4DGaugefields,
     construct_Λmatrix_forSTOUT!,
     evaluate_gaugelinks_evenodd!,
@@ -238,7 +240,11 @@ export Temporalfields, unused!
 export clear_U!, add_U!
 
 export IdentityGauges,
-    RandomGauges, Oneinstanton, calculate_Plaquette, calculate_Polyakov_loop
+    RandomGauges,
+    Oneinstanton,
+    Oneinstanton_SUN_embedded,
+    calculate_Plaquette,
+    calculate_Polyakov_loop
 export B_RandomGauges, B_TfluxGauges, thooftFlux_4D_B_at_bndry
 export ILDG, load_gaugefield!, save_binarydata, load_gaugefield
 export SU2update_KP!, SUNupdate_matrix!, SU3update_matrix!

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -95,3 +95,57 @@ end
     @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; sign=0)
     @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; center=(1, 2, 3))
 end
+
+function normalized_plaquette(U)
+    temp1 = similar(U[1])
+    temp2 = similar(U[1])
+    return calculate_Plaquette(U, temp1, temp2) / (6 * U[1].NV * U[1].NC)
+end
+
+function check_sun_embedded_instanton(NC, block; NDW=0)
+    L = (4, 4, 4, 4)
+    U2 = Oneinstanton(2, NDW, L...)
+    U = Oneinstanton_SUN_embedded(NC, L...; NDW, block)
+    spectator = setdiff(1:NC, block)
+
+    for μ = 1:4
+        for it = 1:L[4], iz = 1:L[3], iy = 1:L[2], ix = 1:L[1]
+            link = Matrix(U[μ][:, :, ix, iy, iz, it])
+            u2 = ComplexF64[
+                U2[μ][1, 1, ix, iy, iz, it] U2[μ][1, 2, ix, iy, iz, it]
+                U2[μ][2, 1, ix, iy, iz, it] U2[μ][2, 2, ix, iy, iz, it]
+            ]
+
+            for b = 1:2, a = 1:2
+                @test link[block[a], block[b]] ≈ u2[a, b]
+            end
+            for c in spectator
+                @test link[c, c] == 1
+                for d = 1:NC
+                    if d != c
+                        @test link[c, d] == 0
+                        @test link[d, c] == 0
+                    end
+                end
+            end
+
+            @test link' * link ≈ Matrix{ComplexF64}(I, NC, NC)
+            @test det(link) ≈ 1
+        end
+    end
+
+    @test normalized_plaquette(U) ≈ (2 * normalized_plaquette(U2) + (NC - 2)) / NC
+end
+
+@testset "SUN embedded instanton public API" begin
+    check_sun_embedded_instanton(3, (1, 2))
+    check_sun_embedded_instanton(3, (1, 3))
+    check_sun_embedded_instanton(3, (2, 3))
+    check_sun_embedded_instanton(4, (2, 4))
+    check_sun_embedded_instanton(5, (2, 5))
+    check_sun_embedded_instanton(3, (1, 3); NDW=1)
+
+    @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; block=(1, 1))
+    @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; block=(1, 4))
+    @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; NDW=-1)
+end


### PR DESCRIPTION
## Summary
- Add explicit `Oneinstanton_SUN_embedded` API without enabling `Oneinstanton(3, ...)`.
- Support serial 4D no-wing and wing fields with keyword `NDW`, `center`, `radius`, `sign`, and `block`.
- Add focused tests for SU(3) block choices, representative NC > 3 blocks, spectator colors, unitarity, determinant, plaquette expectation, invalid inputs, and `NDW=1`.

Stacked on #118, which is stacked on #117 and #116.

## Tests
- `/Users/akio/.juliaup/bin/julia --project=. test/sun_embedded_instanton.jl`
- `/Users/akio/.juliaup/bin/julia --project=. -e 'using Gaugefields, Test, Random; include("test/init.jl")'`