### PR TITLE
Add plaquette topological charge density helper

### DIFF
--- a/docs/codex/su3_embedded_instanton/design.md
+++ b/docs/codex/su3_embedded_instanton/design.md
@@ -217,7 +217,9 @@ Tests:
 - `sum(q) == Q` within tolerance using the same normalization.
 - Cold fields have site-wise density close to zero.
 - SU(2) and SU(Nc)-embedded instantons have matching `q(x)`.
-- `sign=-1` flips the sign of `q(x)`.
+- `sign=-1` flips the sign of scalar `Q`; for one-plaquette density, also
+  bound the local difference from `-q(x)` because the plaquette definition is
+  anchored at a site rather than clover-centered.
 - The density shape matches the lattice shape.
 
 PR-7: connect `q(x)` visualization on the VisualizingLQCD side.

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -926,6 +926,89 @@ function _su2_instanton_link(μ, ix, iy, iz, it, L; center=nothing, radius=nothi
     return exp(im * tau * (1 / 2) * (1 / n2) * (im * radius^2 / (n2 + radius^2)))
 end
 
+function _epsilon_tensor_4d(μ, ν, ρ, σ)
+    p = (μ, ν, ρ, σ)
+    length(unique(p)) == 4 || return 0
+
+    inversions = 0
+    for i = 1:4
+        for j = i+1:4
+            inversions += p[i] > p[j]
+        end
+    end
+    return iseven(inversions) ? 1 : -1
+end
+
+function _site_trace_product(a::AbstractGaugefields{NC,4}, b::AbstractGaugefields{NC,4}, ix, iy, iz, it) where {NC}
+    s = zero(ComplexF64)
+    for j = 1:NC
+        for i = 1:NC
+            s += a[i, j, ix, iy, iz, it] * b[j, i, ix, iy, iz, it]
+        end
+    end
+    return s
+end
+
+function _plaquette_field_strengths(U::Array{T,1}) where {NC,T<:AbstractGaugefields{NC,4}}
+    length(U) == 4 || throw(ArgumentError("U must contain four gauge-link directions"))
+
+    temps = [similar(U[1]), similar(U[1]), similar(U[1]), similar(U[1])]
+    F = Matrix{T}(undef, 4, 4)
+    for μ = 1:4
+        for ν = 1:4
+            F[μ, ν] = similar(U[1])
+        end
+    end
+
+    for μ = 1:4
+        for ν = 1:4
+            if μ != ν
+                plaq = Wilsonline([(μ, 1), (ν, 1), (μ, -1), (ν, -1)])
+                evaluate_gaugelinks!(temps[1], [plaq], U, temps)
+                Traceless_antihermitian!(F[μ, ν], temps[1])
+            end
+        end
+    end
+    return F
+end
+
+function _plaquette_topological_charge_density(U::Array{T,1}) where {NC,T<:AbstractGaugefields{NC,4}}
+    F = _plaquette_field_strengths(U)
+    NX, NY, NZ, NT = U[1].NX, U[1].NY, U[1].NZ, U[1].NT
+    density = zeros(Float64, NX, NY, NZ, NT)
+    epsilon_terms = Tuple{Int,Int,Int,Int,Int}[]
+    for μ = 1:4
+        for ν = 1:4
+            for ρ = 1:4
+                for σ = 1:4
+                    ε = _epsilon_tensor_4d(μ, ν, ρ, σ)
+                    ε != 0 && push!(epsilon_terms, (μ, ν, ρ, σ, ε))
+                end
+            end
+        end
+    end
+
+    for it = 1:NT
+        for iz = 1:NZ
+            for iy = 1:NY
+                for ix = 1:NX
+                    q = zero(ComplexF64)
+                    for (μ, ν, ρ, σ, ε) in epsilon_terms
+                        q += ε * _site_trace_product(F[μ, ν], F[ρ, σ], ix, iy, iz, it)
+                    end
+                    density[ix, iy, iz, it] = -real(q) / (32 * pi^2)
+                end
+            end
+        end
+    end
+
+    return density
+end
+
+function _plaquette_topological_charge(U::Array{<:AbstractGaugefields{NC,4},1}) where {NC}
+    return sum(_plaquette_topological_charge_density(U))
+end
+
 function Oneinstanton_SUN_embedded(
     NC,
     NX,

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -1,7 +1,6 @@
 using Gaugefields
 using Test
 using LinearAlgebra
-import Wilsonloop: make_plaq
 
 const AG = Gaugefields.AbstractGaugefields_module
 
@@ -151,62 +150,23 @@ end
     @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; NDW=-1)
 end
 
-function epsilon4(μ, ν, ρ, σ)
-    p = (μ, ν, ρ, σ)
-    length(unique(p)) == 4 || return 0
-
-    inversions = 0
-    for i = 1:4
-        for j = i+1:4
-            inversions += p[i] > p[j]
-        end
-    end
-    return iseven(inversions) ? 1 : -1
-end
-
-function plaquette_topological_charge(U)
-    Dim = 4
-    temps = [similar(U[1]), similar(U[1]), similar(U[1]), similar(U[1])]
-    F = Matrix{typeof(U[1])}(undef, Dim, Dim)
-    for μ = 1:Dim
-        for ν = 1:Dim
-            F[μ, ν] = similar(U[1])
-        end
-    end
-
-    for μ = 1:Dim
-        for ν = 1:Dim
-            if μ != ν
-                evaluate_gaugelinks!(temps[1], [make_plaq(μ, ν, Dim=Dim)], U, temps)
-                Traceless_antihermitian!(F[μ, ν], temps[1])
-            end
-        end
-    end
-
-    Q = 0.0
-    for μ = 1:Dim
-        for ν = 1:Dim
-            for ρ = 1:Dim
-                for σ = 1:Dim
-                    if μ != ν && ρ != σ
-                        Q += epsilon4(μ, ν, ρ, σ) * tr(F[μ, ν], F[ρ, σ])
-                    end
-                end
-            end
-        end
-    end
-
-    return -real(Q) / (32 * pi^2)
-end
+plaquette_topological_charge(U) = AG._plaquette_topological_charge(U)
+plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_density(U)
 
 @testset "SUN embedded instanton topological charge" begin
     L = (4, 4, 4, 4)
     cold = Initialize_Gaugefields(3, 0, L..., condition="cold")
-    @test isapprox(plaquette_topological_charge(cold), 0; atol=1e-12)
+    cold_density = plaquette_topological_charge_density(cold)
+    @test size(cold_density) == L
+    @test all(isapprox.(cold_density, 0; atol=1e-12))
+    @test isapprox(sum(cold_density), plaquette_topological_charge(cold); atol=1e-12)
 
     U2 = Oneinstanton(2, 0, L...)
+    q2 = plaquette_topological_charge_density(U2)
     Q2 = plaquette_topological_charge(U2)
     @test abs(Q2) > 1
+    @test size(q2) == L
+    @test isapprox(sum(q2), Q2; rtol=1e-12, atol=1e-12)
 
     U3 = Oneinstanton_SUN_embedded(3, L...; block=(1, 2))
     U3_alt = Oneinstanton_SUN_embedded(3, L...; block=(2, 3))
@@ -217,7 +177,14 @@ end
     @test plaquette_topological_charge(U3_alt) ≈ Q2
     @test plaquette_topological_charge(U4) ≈ Q2
     @test plaquette_topological_charge(U5) ≈ Q2
+    @test isapprox(plaquette_topological_charge_density(U3), q2; rtol=1e-12, atol=1e-12)
+    @test isapprox(plaquette_topological_charge_density(U3_alt), q2; rtol=1e-12, atol=1e-12)
+    @test isapprox(plaquette_topological_charge_density(U4), q2; rtol=1e-12, atol=1e-12)
+    @test isapprox(plaquette_topological_charge_density(U5), q2; rtol=1e-12, atol=1e-12)
 
     U3_anti = Oneinstanton_SUN_embedded(3, L...; block=(1, 2), sign=-1)
     @test plaquette_topological_charge(U3_anti) ≈ -Q2
+    q3_anti = plaquette_topological_charge_density(U3_anti)
+    @test isapprox(sum(q3_anti), -Q2; rtol=1e-12, atol=1e-12)
+    @test maximum(abs.(q3_anti .+ q2)) < 2e-5
 end


### PR DESCRIPTION
## Summary
- Add private plaquette topological charge helpers that keep site-wise `q(x)` separate from scalar `Q = sum(q)`.
- Reuse those helpers in the SU(Nc)-embedded instanton tests.
- Update the design note to record that one-plaquette density is site-anchored, so anti-instanton local density is checked with a finite-lattice tolerance while scalar `Q` flips sign.

## Tests
- `/Users/akio/.juliaup/bin/julia --project=. test/sun_embedded_instanton.jl`
- `/Users/akio/.juliaup/bin/julia --project=. -e 'using Gaugefields, Test, Random; include("test/init.jl")'`

Stacked on #120 / `codex/sun-embedded-instanton-q-tests`.