### PR TITLE
Expose plaquette topological charge API

### DIFF
--- a/docs/codex/su3_embedded_instanton/design.md
+++ b/docs/codex/su3_embedded_instanton/design.md
@@ -222,7 +222,23 @@ Tests:
   anchored at a site rather than clover-centered.
 - The density shape matches the lattice shape.
 
-PR-7: connect `q(x)` visualization on the VisualizingLQCD side.
+PR-7: expose minimal public topological charge API.
+
+Candidate public functions:
+
+```julia
+topological_charge_density(U; method=:plaquette)
+topological_charge(U; method=:plaquette)
+```
+
+Tests:
+
+- The public density API returns the same data as the internal plaquette helper.
+- The public scalar API returns `sum(q)` using the same normalization.
+- Unsupported methods such as `method=:clover` throw a clear error until they
+  are implemented.
+
+PR-8: connect `q(x)` visualization on the VisualizingLQCD side.
 
 Tests:
 
@@ -261,7 +277,8 @@ Suggested branch sequence:
 - PR-4: `codex/sun-embedded-instanton-api`
 - PR-5: `codex/sun-embedded-instanton-q-tests`
 - PR-6: `codex/sun-embedded-instanton-density`
-- PR-7: `codex/sun-embedded-instanton-visualization`
+- PR-7: `codex/topological-charge-density-api`
+- PR-8: `codex/sun-embedded-instanton-visualization`
 
 Normal flow:
 

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -1009,6 +1009,14 @@ function _plaquette_topological_charge(U::Array{<:AbstractGaugefields{NC,4},1}) 
     return sum(_plaquette_topological_charge_density(U))
 end
 
+function _check_serial_topological_charge_field(U)
+    T = eltype(U)
+    if !(T <: Gaugefields_4D_nowing || T <: Gaugefields_4D_wing)
+        throw(ArgumentError("topological charge only supports serial 4D gauge fields"))
+    end
+    return nothing
+end
+
 """
     topological_charge_density(U; method=:plaquette)
 
@@ -1017,6 +1025,7 @@ The scalar topological charge is `sum(topological_charge_density(U))`.
 """
 function topological_charge_density(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:plaquette) where {NC,Dim}
     Dim == 4 || throw(ArgumentError("topological_charge_density only supports 4D gauge fields"))
+    _check_serial_topological_charge_field(U)
     method == :plaquette || throw(ArgumentError("only method=:plaquette is supported"))
     return _plaquette_topological_charge_density(U)
 end
@@ -1028,6 +1037,7 @@ Return the scalar topological charge `Q` for a 4D gauge field.
 """
 function topological_charge(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:plaquette) where {NC,Dim}
     Dim == 4 || throw(ArgumentError("topological_charge only supports 4D gauge fields"))
+    _check_serial_topological_charge_field(U)
     method == :plaquette || throw(ArgumentError("only method=:plaquette is supported"))
     return _plaquette_topological_charge(U)
 end

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -1009,6 +1009,29 @@ function _plaquette_topological_charge(U::Array{<:AbstractGaugefields{NC,4},1}) 
     return sum(_plaquette_topological_charge_density(U))
 end
 
+"""
+    topological_charge_density(U; method=:plaquette)
+
+Return the site-wise topological charge density `q(x)` for a 4D gauge field.
+The scalar topological charge is `sum(topological_charge_density(U))`.
+"""
+function topological_charge_density(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:plaquette) where {NC,Dim}
+    Dim == 4 || throw(ArgumentError("topological_charge_density only supports 4D gauge fields"))
+    method == :plaquette || throw(ArgumentError("only method=:plaquette is supported"))
+    return _plaquette_topological_charge_density(U)
+end
+
+"""
+    topological_charge(U; method=:plaquette)
+
+Return the scalar topological charge `Q` for a 4D gauge field.
+"""
+function topological_charge(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:plaquette) where {NC,Dim}
+    Dim == 4 || throw(ArgumentError("topological_charge only supports 4D gauge fields"))
+    method == :plaquette || throw(ArgumentError("only method=:plaquette is supported"))
+    return _plaquette_topological_charge(U)
+end
+
 function Oneinstanton_SUN_embedded(
     NC,
     NX,

--- a/src/Gaugefields.jl
+++ b/src/Gaugefields.jl
@@ -66,6 +66,8 @@ import .AbstractGaugefields_module:
     Oneinstanton,
     Oneinstanton_SUN_embedded,
     calculate_Plaquette,
+    topological_charge_density,
+    topological_charge,
     calculate_Polyakov_loop,
     map_U!,
     evaluate_gaugelinks_evenodd!,
@@ -213,6 +215,8 @@ import .AbstractGaugefields_module:
     Oneinstanton,
     Oneinstanton_SUN_embedded,
     Initialize_4DGaugefields,
+    topological_charge_density,
+    topological_charge,
     construct_Λmatrix_forSTOUT!,
     evaluate_gaugelinks_evenodd!,
     map_U!,
@@ -244,6 +248,8 @@ export IdentityGauges,
     Oneinstanton,
     Oneinstanton_SUN_embedded,
     calculate_Plaquette,
+    topological_charge_density,
+    topological_charge,
     calculate_Polyakov_loop
 export B_RandomGauges, B_TfluxGauges, thooftFlux_4D_B_at_bndry
 export ILDG, load_gaugefield!, save_binarydata, load_gaugefield

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -171,6 +171,9 @@ plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_densi
     @test topological_charge(U2) ≈ Q2
     @test_throws ArgumentError topological_charge_density(U2; method=:clover)
     @test_throws ArgumentError topological_charge(U2; method=:clover)
+    accelerator_field = Initialize_Gaugefields(3, 0, L...; condition="cold", cuda=true)
+    @test_throws ArgumentError topological_charge_density(accelerator_field)
+    @test_throws ArgumentError topological_charge(accelerator_field)
 
     U3 = Oneinstanton_SUN_embedded(3, L...; block=(1, 2))
     U3_alt = Oneinstanton_SUN_embedded(3, L...; block=(2, 3))

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -167,6 +167,10 @@ plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_densi
     @test abs(Q2) > 1
     @test size(q2) == L
     @test isapprox(sum(q2), Q2; rtol=1e-12, atol=1e-12)
+    @test topological_charge_density(U2) ≈ q2
+    @test topological_charge(U2) ≈ Q2
+    @test_throws ArgumentError topological_charge_density(U2; method=:clover)
+    @test_throws ArgumentError topological_charge(U2; method=:clover)
 
     U3 = Oneinstanton_SUN_embedded(3, L...; block=(1, 2))
     U3_alt = Oneinstanton_SUN_embedded(3, L...; block=(2, 3))
@@ -177,6 +181,7 @@ plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_densi
     @test plaquette_topological_charge(U3_alt) ≈ Q2
     @test plaquette_topological_charge(U4) ≈ Q2
     @test plaquette_topological_charge(U5) ≈ Q2
+    @test topological_charge(U3) ≈ Q2
     @test isapprox(plaquette_topological_charge_density(U3), q2; rtol=1e-12, atol=1e-12)
     @test isapprox(plaquette_topological_charge_density(U3_alt), q2; rtol=1e-12, atol=1e-12)
     @test isapprox(plaquette_topological_charge_density(U4), q2; rtol=1e-12, atol=1e-12)


### PR DESCRIPTION
## Summary
- Export `topological_charge_density(U; method=:plaquette)` for site-wise `q(x)`.
- Export `topological_charge(U; method=:plaquette)` for scalar `Q` using the same normalization.
- Keep the first public surface limited to the plaquette definition; unsupported methods throw `ArgumentError`.
- Update the design note so the visualization step follows this API PR.

## Tests
- `/Users/akio/.juliaup/bin/julia --project=. test/sun_embedded_instanton.jl`
- `/Users/akio/.juliaup/bin/julia --project=. -e 'using Gaugefields, Test, Random; include("test/init.jl")'`

Stacked on #121 / `codex/sun-embedded-instanton-density`.