### PR TITLE
Land SU(Nc)-embedded SU(2) instanton stack

### DIFF
--- a/docs/codex/su3_embedded_instanton/design.md
+++ b/docs/codex/su3_embedded_instanton/design.md
@@ -217,7 +217,9 @@ Tests:
 - `sum(q) == Q` within tolerance using the same normalization.
 - Cold fields have site-wise density close to zero.
 - SU(2) and SU(Nc)-embedded instantons have matching `q(x)`.
-- `sign=-1` flips the sign of `q(x)`.
+- `sign=-1` flips the sign of scalar `Q`; for one-plaquette density, also
+  bound the local difference from `-q(x)` because the plaquette definition is
+  anchored at a site rather than clover-centered.
 - The density shape matches the lattice shape.
 
 PR-7: connect `q(x)` visualization on the VisualizingLQCD side.

--- a/docs/codex/su3_embedded_instanton/design.md
+++ b/docs/codex/su3_embedded_instanton/design.md
@@ -222,7 +222,23 @@ Tests:
   anchored at a site rather than clover-centered.
 - The density shape matches the lattice shape.
 
-PR-7: connect `q(x)` visualization on the VisualizingLQCD side.
+PR-7: expose minimal public topological charge API.
+
+Candidate public functions:
+
+```julia
+topological_charge_density(U; method=:plaquette)
+topological_charge(U; method=:plaquette)
+```
+
+Tests:
+
+- The public density API returns the same data as the internal plaquette helper.
+- The public scalar API returns `sum(q)` using the same normalization.
+- Unsupported methods such as `method=:clover` throw a clear error until they
+  are implemented.
+
+PR-8: connect `q(x)` visualization on the VisualizingLQCD side.
 
 Tests:
 
@@ -261,7 +277,8 @@ Suggested branch sequence:
 - PR-4: `codex/sun-embedded-instanton-api`
 - PR-5: `codex/sun-embedded-instanton-q-tests`
 - PR-6: `codex/sun-embedded-instanton-density`
-- PR-7: `codex/sun-embedded-instanton-visualization`
+- PR-7: `codex/topological-charge-density-api`
+- PR-8: `codex/sun-embedded-instanton-visualization`
 
 Normal flow:
 

--- a/src/4D/nowing/gaugefields_4D_nowing.jl
+++ b/src/4D/nowing/gaugefields_4D_nowing.jl
@@ -327,25 +327,6 @@ function Oneinstanton_4D_nowing(NC, NX, NY, NZ, NT; verbose_level=2)
 
     println("# Starting from a instanton backgorund with radius R=$R ")
     inst_cent = [L[1] / 2 + 0.5, L[2] / 2 + 0.5, L[3] / 2 + 0.5, L[4] / 2 + 0.5]
-    #eps = 1/10000000
-    s1 = [
-        0.0 1.0
-        1.0 0.0
-    ]
-    s2 = [
-        0.0 -im*1.0
-        im*1.0 0.0
-    ]
-    s3 = [
-        1.0 0.0
-        0.0 -1.0
-    ]
-    En = [
-        1.0 0.0
-        0.0 1.0
-    ]
-    ss = [im * s1, im * s2, im * s3, En]
-    sd = [-im * s1, -im * s2, -im * s3, En]
     nn = 0
 
     for it = 1:NT
@@ -353,19 +334,8 @@ function Oneinstanton_4D_nowing(NC, NX, NY, NZ, NT; verbose_level=2)
             for iy = 1:NY
                 for ix = 1:NX
                     nn += 0
-                    nv = [ix - 1, iy - 1, iz - 1, it - 1] - inst_cent
-                    n2 = nv ⋅ nv
                     for mu = 1:4
-                        tau = [
-                            0 0
-                            0 0
-                        ]
-                        for nu = 1:4
-                            smunu = sd[mu] * ss[nu] - sd[nu] * ss[mu]
-                            tau += smunu * nv[nu]
-                        end
-                        sq = sqrt(n2 + R^2)
-                        tau = exp(im * tau * (1 / 2) * (1 / (n2)) * (im * R^2 / (n2 + R^2))) #1b
+                        tau = _su2_instanton_link(mu, ix, iy, iz, it, L; center=inst_cent, radius=R)
                         for j = 1:2
                             for i = 1:2
                                 U[mu][i, j, ix, iy, iz, it] = tau[i, j]

--- a/src/4D/wing/gaugefields_4D_wing.jl
+++ b/src/4D/wing/gaugefields_4D_wing.jl
@@ -400,25 +400,6 @@ function Oneinstanton_4D_wing(NC, NX, NY, NZ, NT, NDW; verbose_level=2)
 
     println("# Starting from a instanton backgorund with radius R=$R ")
     inst_cent = [L[1] / 2 + 0.5, L[2] / 2 + 0.5, L[3] / 2 + 0.5, L[4] / 2 + 0.5]
-    #eps = 1/10000000
-    s1 = [
-        0.0 1.0
-        1.0 0.0
-    ]
-    s2 = [
-        0.0 -im*1.0
-        im*1.0 0.0
-    ]
-    s3 = [
-        1.0 0.0
-        0.0 -1.0
-    ]
-    En = [
-        1.0 0.0
-        0.0 1.0
-    ]
-    ss = [im * s1, im * s2, im * s3, En]
-    sd = [-im * s1, -im * s2, -im * s3, En]
     nn = 0
 
     for it = 1:NT
@@ -426,19 +407,8 @@ function Oneinstanton_4D_wing(NC, NX, NY, NZ, NT, NDW; verbose_level=2)
             for iy = 1:NY
                 for ix = 1:NX
                     nn += 0
-                    nv = [ix - 1, iy - 1, iz - 1, it - 1] - inst_cent
-                    n2 = nv ⋅ nv
                     for mu = 1:4
-                        tau = [
-                            0 0
-                            0 0
-                        ]
-                        for nu = 1:4
-                            smunu = sd[mu] * ss[nu] - sd[nu] * ss[mu]
-                            tau += smunu * nv[nu]
-                        end
-                        sq = sqrt(n2 + R^2)
-                        tau = exp(im * tau * (1 / 2) * (1 / (n2)) * (im * R^2 / (n2 + R^2))) #1b
+                        tau = _su2_instanton_link(mu, ix, iy, iz, it, L; center=inst_cent, radius=R)
                         for j = 1:2
                             for i = 1:2
                                 U[mu][i, j, ix, iy, iz, it] = tau[i, j]

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -926,6 +926,89 @@ function _su2_instanton_link(μ, ix, iy, iz, it, L; center=nothing, radius=nothi
     return exp(im * tau * (1 / 2) * (1 / n2) * (im * radius^2 / (n2 + radius^2)))
 end
 
+function _epsilon_tensor_4d(μ, ν, ρ, σ)
+    p = (μ, ν, ρ, σ)
+    length(unique(p)) == 4 || return 0
+
+    inversions = 0
+    for i = 1:4
+        for j = i+1:4
+            inversions += p[i] > p[j]
+        end
+    end
+    return iseven(inversions) ? 1 : -1
+end
+
+function _site_trace_product(a::AbstractGaugefields{NC,4}, b::AbstractGaugefields{NC,4}, ix, iy, iz, it) where {NC}
+    s = zero(ComplexF64)
+    for j = 1:NC
+        for i = 1:NC
+            s += a[i, j, ix, iy, iz, it] * b[j, i, ix, iy, iz, it]
+        end
+    end
+    return s
+end
+
+function _plaquette_field_strengths(U::Array{T,1}) where {NC,T<:AbstractGaugefields{NC,4}}
+    length(U) == 4 || throw(ArgumentError("U must contain four gauge-link directions"))
+
+    temps = [similar(U[1]), similar(U[1]), similar(U[1]), similar(U[1])]
+    F = Matrix{T}(undef, 4, 4)
+    for μ = 1:4
+        for ν = 1:4
+            F[μ, ν] = similar(U[1])
+        end
+    end
+
+    for μ = 1:4
+        for ν = 1:4
+            if μ != ν
+                plaq = Wilsonline([(μ, 1), (ν, 1), (μ, -1), (ν, -1)])
+                evaluate_gaugelinks!(temps[1], [plaq], U, temps)
+                Traceless_antihermitian!(F[μ, ν], temps[1])
+            end
+        end
+    end
+    return F
+end
+
+function _plaquette_topological_charge_density(U::Array{T,1}) where {NC,T<:AbstractGaugefields{NC,4}}
+    F = _plaquette_field_strengths(U)
+    NX, NY, NZ, NT = U[1].NX, U[1].NY, U[1].NZ, U[1].NT
+    density = zeros(Float64, NX, NY, NZ, NT)
+    epsilon_terms = Tuple{Int,Int,Int,Int,Int}[]
+    for μ = 1:4
+        for ν = 1:4
+            for ρ = 1:4
+                for σ = 1:4
+                    ε = _epsilon_tensor_4d(μ, ν, ρ, σ)
+                    ε != 0 && push!(epsilon_terms, (μ, ν, ρ, σ, ε))
+                end
+            end
+        end
+    end
+
+    for it = 1:NT
+        for iz = 1:NZ
+            for iy = 1:NY
+                for ix = 1:NX
+                    q = zero(ComplexF64)
+                    for (μ, ν, ρ, σ, ε) in epsilon_terms
+                        q += ε * _site_trace_product(F[μ, ν], F[ρ, σ], ix, iy, iz, it)
+                    end
+                    density[ix, iy, iz, it] = -real(q) / (32 * pi^2)
+                end
+            end
+        end
+    end
+
+    return density
+end
+
+function _plaquette_topological_charge(U::Array{<:AbstractGaugefields{NC,4},1}) where {NC}
+    return sum(_plaquette_topological_charge_density(U))
+end
+
 function Oneinstanton_SUN_embedded(
     NC,
     NX,

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -882,6 +882,46 @@ function _embed_su2_matrix_in_sun!(U, u2, block)
     return U
 end
 
+function _su2_instanton_link(μ, ix, iy, iz, it, L; center=nothing, radius=nothing, sign=+1)
+    length(L) == 4 || throw(ArgumentError("L must contain four lattice extents"))
+    1 <= μ <= 4 || throw(ArgumentError("μ must be in 1:4"))
+    sign in (-1, +1) || throw(ArgumentError("sign must be +1 or -1"))
+
+    center === nothing && (center = (L[1] / 2 + 0.5, L[2] / 2 + 0.5, L[3] / 2 + 0.5, L[4] / 2 + 0.5))
+    length(center) == 4 || throw(ArgumentError("center must contain four coordinates"))
+    radius === nothing && (radius = div(L[1], 2))
+    radius > 0 || throw(ArgumentError("radius must be positive"))
+
+    s1 = ComplexF64[
+        0 1
+        1 0
+    ]
+    s2 = ComplexF64[
+        0 -im
+        im 0
+    ]
+    s3 = ComplexF64[
+        1 0
+        0 -1
+    ]
+    En = ComplexF64[
+        1 0
+        0 1
+    ]
+    ss = (im * s1, im * s2, im * s3, En)
+    sd = (-im * s1, -im * s2, -im * s3, En)
+
+    nv = ComplexF64[ix - 1 - center[1], iy - 1 - center[2], iz - 1 - center[3], it - 1 - center[4]]
+    n2 = real(nv ⋅ nv)
+    tau = zeros(ComplexF64, 2, 2)
+    for ν = 1:4
+        smunu = sd[μ] * ss[ν] - sd[ν] * ss[μ]
+        tau += smunu * nv[ν]
+    end
+
+    return exp(im * tau * (1 / 2) * (1 / n2) * (im * sign * radius^2 / (n2 + radius^2)))
+end
+
 function construct_gauges(NC, NDW, NN...; mpi=false, PEs=nothing, mpiinit=nothing)
     dim = length(NN)
     if mpi
@@ -2818,4 +2858,3 @@ end
 include("ND.jl")
 
 end
-

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -1009,6 +1009,14 @@ function _plaquette_topological_charge(U::Array{<:AbstractGaugefields{NC,4},1}) 
     return sum(_plaquette_topological_charge_density(U))
 end
 
+function _check_serial_topological_charge_field(U)
+    T = eltype(U)
+    if !(T <: Gaugefields_4D_nowing || T <: Gaugefields_4D_wing)
+        throw(ArgumentError("topological charge only supports serial 4D gauge fields"))
+    end
+    return nothing
+end
+
 """
     topological_charge_density(U; method=:plaquette)
 
@@ -1017,6 +1025,7 @@ The scalar topological charge is `sum(topological_charge_density(U))`.
 """
 function topological_charge_density(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:plaquette) where {NC,Dim}
     Dim == 4 || throw(ArgumentError("topological_charge_density only supports 4D gauge fields"))
+    _check_serial_topological_charge_field(U)
     method == :plaquette || throw(ArgumentError("only method=:plaquette is supported"))
     return _plaquette_topological_charge_density(U)
 end
@@ -1028,6 +1037,7 @@ Return the scalar topological charge `Q` for a 4D gauge field.
 """
 function topological_charge(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:plaquette) where {NC,Dim}
     Dim == 4 || throw(ArgumentError("topological_charge only supports 4D gauge fields"))
+    _check_serial_topological_charge_field(U)
     method == :plaquette || throw(ArgumentError("only method=:plaquette is supported"))
     return _plaquette_topological_charge(U)
 end

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -851,6 +851,37 @@ function Oneinstanton(NC, NDW, NN...; mpi=false, PEs=nothing, mpiinit=nothing)
     return U
 end
 
+function _validate_su2_embedding_block(NC, block)
+    NC isa Integer || throw(ArgumentError("NC must be an integer"))
+    NC >= 2 || throw(ArgumentError("NC must be at least 2"))
+    length(block) == 2 || throw(ArgumentError("block must contain two color indices"))
+
+    i, j = block
+    i isa Integer || throw(ArgumentError("block indices must be integers"))
+    j isa Integer || throw(ArgumentError("block indices must be integers"))
+    1 <= i < j <= NC || throw(ArgumentError("block must satisfy 1 <= i < j <= NC"))
+
+    return (Int(i), Int(j))
+end
+
+function _embed_su2_matrix_in_sun!(U, u2, block)
+    size(u2) == (2, 2) || throw(ArgumentError("u2 must be a 2 by 2 matrix"))
+    NC, NC2 = size(U)
+    NC == NC2 || throw(ArgumentError("U must be a square matrix"))
+    i, j = _validate_su2_embedding_block(NC, block)
+
+    fill!(U, zero(eltype(U)))
+    for c = 1:NC
+        U[c, c] = one(eltype(U))
+    end
+
+    U[i, i] = u2[1, 1]
+    U[i, j] = u2[1, 2]
+    U[j, i] = u2[2, 1]
+    U[j, j] = u2[2, 2]
+    return U
+end
+
 function construct_gauges(NC, NDW, NN...; mpi=false, PEs=nothing, mpiinit=nothing)
     dim = length(NN)
     if mpi
@@ -2787,5 +2818,4 @@ end
 include("ND.jl")
 
 end
-
 

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -1009,6 +1009,29 @@ function _plaquette_topological_charge(U::Array{<:AbstractGaugefields{NC,4},1}) 
     return sum(_plaquette_topological_charge_density(U))
 end
 
+"""
+    topological_charge_density(U; method=:plaquette)
+
+Return the site-wise topological charge density `q(x)` for a 4D gauge field.
+The scalar topological charge is `sum(topological_charge_density(U))`.
+"""
+function topological_charge_density(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:plaquette) where {NC,Dim}
+    Dim == 4 || throw(ArgumentError("topological_charge_density only supports 4D gauge fields"))
+    method == :plaquette || throw(ArgumentError("only method=:plaquette is supported"))
+    return _plaquette_topological_charge_density(U)
+end
+
+"""
+    topological_charge(U; method=:plaquette)
+
+Return the scalar topological charge `Q` for a 4D gauge field.
+"""
+function topological_charge(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:plaquette) where {NC,Dim}
+    Dim == 4 || throw(ArgumentError("topological_charge only supports 4D gauge fields"))
+    method == :plaquette || throw(ArgumentError("only method=:plaquette is supported"))
+    return _plaquette_topological_charge(U)
+end
+
 function Oneinstanton_SUN_embedded(
     NC,
     NX,

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -922,6 +922,59 @@ function _su2_instanton_link(μ, ix, iy, iz, it, L; center=nothing, radius=nothi
     return exp(im * tau * (1 / 2) * (1 / n2) * (im * sign * radius^2 / (n2 + radius^2)))
 end
 
+function Oneinstanton_SUN_embedded(
+    NC,
+    NX,
+    NY,
+    NZ,
+    NT;
+    NDW=0,
+    center=(NX / 2 + 0.5, NY / 2 + 0.5, NZ / 2 + 0.5, NT / 2 + 0.5),
+    radius=div(NX, 2),
+    sign=+1,
+    block=(1, 2),
+    verbose_level=2,
+)
+    NDW isa Integer || throw(ArgumentError("NDW must be an integer"))
+    NDW >= 0 || throw(ArgumentError("NDW must be nonnegative"))
+    block = _validate_su2_embedding_block(NC, block)
+    L = (NX, NY, NZ, NT)
+
+    if NDW == 0
+        u = Gaugefields_4D_nowing(NC, NX, NY, NZ, NT, verbose_level=verbose_level)
+    else
+        u = Gaugefields_4D_wing(NC, NDW, NX, NY, NZ, NT, verbose_level=verbose_level)
+    end
+
+    U = Array{typeof(u),1}(undef, 4)
+    U[1] = u
+    for μ = 2:4
+        U[μ] = similar(u)
+    end
+
+    sunlink = zeros(ComplexF64, NC, NC)
+    for it = 1:NT
+        for iz = 1:NZ
+            for iy = 1:NY
+                for ix = 1:NX
+                    for μ = 1:4
+                        su2link = _su2_instanton_link(μ, ix, iy, iz, it, L; center, radius, sign)
+                        _embed_su2_matrix_in_sun!(sunlink, su2link, block)
+                        for j = 1:NC
+                            for i = 1:NC
+                                U[μ][i, j, ix, iy, iz, it] = sunlink[i, j]
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    set_wing_U!(U)
+    return U
+end
+
 function construct_gauges(NC, NDW, NN...; mpi=false, PEs=nothing, mpiinit=nothing)
     dim = length(NN)
     if mpi

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -915,11 +915,15 @@ function _su2_instanton_link(μ, ix, iy, iz, it, L; center=nothing, radius=nothi
     n2 = real(nv ⋅ nv)
     tau = zeros(ComplexF64, 2, 2)
     for ν = 1:4
-        smunu = sd[μ] * ss[ν] - sd[ν] * ss[μ]
+        smunu = if sign == +1
+            sd[μ] * ss[ν] - sd[ν] * ss[μ]
+        else
+            ss[μ] * sd[ν] - ss[ν] * sd[μ]
+        end
         tau += smunu * nv[ν]
     end
 
-    return exp(im * tau * (1 / 2) * (1 / n2) * (im * sign * radius^2 / (n2 + radius^2)))
+    return exp(im * tau * (1 / 2) * (1 / n2) * (im * radius^2 / (n2 + radius^2)))
 end
 
 function Oneinstanton_SUN_embedded(

--- a/src/Gaugefields.jl
+++ b/src/Gaugefields.jl
@@ -66,6 +66,8 @@ import .AbstractGaugefields_module:
     Oneinstanton,
     Oneinstanton_SUN_embedded,
     calculate_Plaquette,
+    topological_charge_density,
+    topological_charge,
     calculate_Polyakov_loop,
     map_U!,
     evaluate_gaugelinks_evenodd!,
@@ -213,6 +215,8 @@ import .AbstractGaugefields_module:
     Oneinstanton,
     Oneinstanton_SUN_embedded,
     Initialize_4DGaugefields,
+    topological_charge_density,
+    topological_charge,
     construct_Λmatrix_forSTOUT!,
     evaluate_gaugelinks_evenodd!,
     map_U!,
@@ -244,6 +248,8 @@ export IdentityGauges,
     Oneinstanton,
     Oneinstanton_SUN_embedded,
     calculate_Plaquette,
+    topological_charge_density,
+    topological_charge,
     calculate_Polyakov_loop
 export B_RandomGauges, B_TfluxGauges, thooftFlux_4D_B_at_bndry
 export ILDG, load_gaugefield!, save_binarydata, load_gaugefield

--- a/src/Gaugefields.jl
+++ b/src/Gaugefields.jl
@@ -64,6 +64,7 @@ import .AbstractGaugefields_module:
     IdentityGauges,
     RandomGauges,
     Oneinstanton,
+    Oneinstanton_SUN_embedded,
     calculate_Plaquette,
     calculate_Polyakov_loop,
     map_U!,
@@ -210,6 +211,7 @@ import .AbstractGaugefields_module:
     IdentityGauges,
     RandomGauges,
     Oneinstanton,
+    Oneinstanton_SUN_embedded,
     Initialize_4DGaugefields,
     construct_Λmatrix_forSTOUT!,
     evaluate_gaugelinks_evenodd!,
@@ -238,7 +240,11 @@ export Temporalfields, unused!
 export clear_U!, add_U!
 
 export IdentityGauges,
-    RandomGauges, Oneinstanton, calculate_Plaquette, calculate_Polyakov_loop
+    RandomGauges,
+    Oneinstanton,
+    Oneinstanton_SUN_embedded,
+    calculate_Plaquette,
+    calculate_Polyakov_loop
 export B_RandomGauges, B_TfluxGauges, thooftFlux_4D_B_at_bndry
 export ILDG, load_gaugefield!, save_binarydata, load_gaugefield
 export SU2update_KP!, SUNupdate_matrix!, SU3update_matrix!

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,11 @@ end
     include("init.jl")
 end
 
+@testset "SUN embedded instanton helpers" begin
+    println("SUN embedded instanton helpers")
+    include("sun_embedded_instanton.jl")
+end
+
 
 
 @testset "HMC nowing" begin
@@ -114,7 +119,6 @@ end
 @testset "Gaugefields.jl" begin
     # Write your tests here.
 end
-
 
 
 

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -59,3 +59,39 @@ end
     @test_throws ArgumentError AG._embed_su2_matrix_in_sun!(zeros(3, 3), zeros(3, 3), (1, 2))
     @test_throws ArgumentError AG._embed_su2_matrix_in_sun!(zeros(3, 2), sample_su2_matrix(), (1, 2))
 end
+
+function check_su2_instanton_links(U)
+    L = (U[1].NX, U[1].NY, U[1].NZ, U[1].NT)
+    center = (L[1] / 2 + 0.5, L[2] / 2 + 0.5, L[3] / 2 + 0.5, L[4] / 2 + 0.5)
+    radius = div(L[1], 2)
+
+    for μ = 1:4
+        for it = 1:L[4], iz = 1:L[3], iy = 1:L[2], ix = 1:L[1]
+            link = AG._su2_instanton_link(μ, ix, iy, iz, it, L; center, radius)
+            measured = ComplexF64[
+                U[μ][1, 1, ix, iy, iz, it] U[μ][1, 2, ix, iy, iz, it]
+                U[μ][2, 1, ix, iy, iz, it] U[μ][2, 2, ix, iy, iz, it]
+            ]
+
+            @test measured ≈ link
+            @test link' * link ≈ Matrix{ComplexF64}(I, 2, 2)
+            @test det(link) ≈ 1
+        end
+    end
+end
+
+@testset "SU(2) instanton link helper" begin
+    check_su2_instanton_links(Oneinstanton(2, 0, 4, 4, 4, 4))
+    check_su2_instanton_links(Oneinstanton(2, 1, 4, 4, 4, 4))
+
+    L = (4, 4, 4, 4)
+    anti_link = AG._su2_instanton_link(1, 1, 1, 1, 1, L; sign=-1)
+    @test anti_link' * anti_link ≈ Matrix{ComplexF64}(I, 2, 2)
+    @test det(anti_link) ≈ 1
+
+    @test_throws ArgumentError AG._su2_instanton_link(0, 1, 1, 1, 1, L)
+    @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, (4, 4, 4))
+    @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; radius=0)
+    @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; sign=0)
+    @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; center=(1, 2, 3))
+end

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -1,0 +1,61 @@
+using Gaugefields
+using Test
+using LinearAlgebra
+
+const AG = Gaugefields.AbstractGaugefields_module
+
+function sample_su2_matrix()
+    c = cos(0.37)
+    s = sin(0.37)
+    return ComplexF64[
+        c im*s
+        im*s c
+    ]
+end
+
+function check_su2_embedding(NC, block)
+    u2 = sample_su2_matrix()
+    U = fill(99.0 + 99.0im, NC, NC)
+
+    @test AG._embed_su2_matrix_in_sun!(U, u2, block) === U
+    i, j = block
+    spectator = setdiff(1:NC, block)
+
+    @test U[i, i] == u2[1, 1]
+    @test U[i, j] == u2[1, 2]
+    @test U[j, i] == u2[2, 1]
+    @test U[j, j] == u2[2, 2]
+
+    for c in spectator
+        @test U[c, c] == 1
+        for d = 1:NC
+            if d != c
+                @test U[c, d] == 0
+                @test U[d, c] == 0
+            end
+        end
+    end
+
+    @test U' * U ≈ Matrix{ComplexF64}(I, NC, NC)
+    @test det(U) ≈ 1
+end
+
+@testset "SU(2) matrix embedding into SU(Nc)" begin
+    @test AG._validate_su2_embedding_block(3, (1, 2)) == (1, 2)
+    @test AG._validate_su2_embedding_block(4, [2, 4]) == (2, 4)
+
+    check_su2_embedding(3, (1, 2))
+    check_su2_embedding(3, (1, 3))
+    check_su2_embedding(3, (2, 3))
+    check_su2_embedding(4, (2, 4))
+    check_su2_embedding(5, (2, 5))
+
+    @test_throws ArgumentError AG._validate_su2_embedding_block(1, (1, 2))
+    @test_throws ArgumentError AG._validate_su2_embedding_block(3, (1, 1))
+    @test_throws ArgumentError AG._validate_su2_embedding_block(3, (0, 2))
+    @test_throws ArgumentError AG._validate_su2_embedding_block(3, (1, 4))
+    @test_throws ArgumentError AG._validate_su2_embedding_block(3, (2, 1))
+    @test_throws ArgumentError AG._validate_su2_embedding_block(3, (1, 2, 3))
+    @test_throws ArgumentError AG._embed_su2_matrix_in_sun!(zeros(3, 3), zeros(3, 3), (1, 2))
+    @test_throws ArgumentError AG._embed_su2_matrix_in_sun!(zeros(3, 2), sample_su2_matrix(), (1, 2))
+end

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -1,6 +1,7 @@
 using Gaugefields
 using Test
 using LinearAlgebra
+import Wilsonloop: make_plaq
 
 const AG = Gaugefields.AbstractGaugefields_module
 
@@ -148,4 +149,75 @@ end
     @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; block=(1, 1))
     @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; block=(1, 4))
     @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; NDW=-1)
+end
+
+function epsilon4(μ, ν, ρ, σ)
+    p = (μ, ν, ρ, σ)
+    length(unique(p)) == 4 || return 0
+
+    inversions = 0
+    for i = 1:4
+        for j = i+1:4
+            inversions += p[i] > p[j]
+        end
+    end
+    return iseven(inversions) ? 1 : -1
+end
+
+function plaquette_topological_charge(U)
+    Dim = 4
+    temps = [similar(U[1]), similar(U[1]), similar(U[1]), similar(U[1])]
+    F = Matrix{typeof(U[1])}(undef, Dim, Dim)
+    for μ = 1:Dim
+        for ν = 1:Dim
+            F[μ, ν] = similar(U[1])
+        end
+    end
+
+    for μ = 1:Dim
+        for ν = 1:Dim
+            if μ != ν
+                evaluate_gaugelinks!(temps[1], [make_plaq(μ, ν, Dim=Dim)], U, temps)
+                Traceless_antihermitian!(F[μ, ν], temps[1])
+            end
+        end
+    end
+
+    Q = 0.0
+    for μ = 1:Dim
+        for ν = 1:Dim
+            for ρ = 1:Dim
+                for σ = 1:Dim
+                    if μ != ν && ρ != σ
+                        Q += epsilon4(μ, ν, ρ, σ) * tr(F[μ, ν], F[ρ, σ])
+                    end
+                end
+            end
+        end
+    end
+
+    return -real(Q) / (32 * pi^2)
+end
+
+@testset "SUN embedded instanton topological charge" begin
+    L = (4, 4, 4, 4)
+    cold = Initialize_Gaugefields(3, 0, L..., condition="cold")
+    @test isapprox(plaquette_topological_charge(cold), 0; atol=1e-12)
+
+    U2 = Oneinstanton(2, 0, L...)
+    Q2 = plaquette_topological_charge(U2)
+    @test abs(Q2) > 1
+
+    U3 = Oneinstanton_SUN_embedded(3, L...; block=(1, 2))
+    U3_alt = Oneinstanton_SUN_embedded(3, L...; block=(2, 3))
+    U4 = Oneinstanton_SUN_embedded(4, L...; block=(2, 4))
+    U5 = Oneinstanton_SUN_embedded(5, L...; block=(2, 5))
+
+    @test plaquette_topological_charge(U3) ≈ Q2
+    @test plaquette_topological_charge(U3_alt) ≈ Q2
+    @test plaquette_topological_charge(U4) ≈ Q2
+    @test plaquette_topological_charge(U5) ≈ Q2
+
+    U3_anti = Oneinstanton_SUN_embedded(3, L...; block=(1, 2), sign=-1)
+    @test plaquette_topological_charge(U3_anti) ≈ -Q2
 end

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -95,3 +95,57 @@ end
     @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; sign=0)
     @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; center=(1, 2, 3))
 end
+
+function normalized_plaquette(U)
+    temp1 = similar(U[1])
+    temp2 = similar(U[1])
+    return calculate_Plaquette(U, temp1, temp2) / (6 * U[1].NV * U[1].NC)
+end
+
+function check_sun_embedded_instanton(NC, block; NDW=0)
+    L = (4, 4, 4, 4)
+    U2 = Oneinstanton(2, NDW, L...)
+    U = Oneinstanton_SUN_embedded(NC, L...; NDW, block)
+    spectator = setdiff(1:NC, block)
+
+    for μ = 1:4
+        for it = 1:L[4], iz = 1:L[3], iy = 1:L[2], ix = 1:L[1]
+            link = Matrix(U[μ][:, :, ix, iy, iz, it])
+            u2 = ComplexF64[
+                U2[μ][1, 1, ix, iy, iz, it] U2[μ][1, 2, ix, iy, iz, it]
+                U2[μ][2, 1, ix, iy, iz, it] U2[μ][2, 2, ix, iy, iz, it]
+            ]
+
+            for b = 1:2, a = 1:2
+                @test link[block[a], block[b]] ≈ u2[a, b]
+            end
+            for c in spectator
+                @test link[c, c] == 1
+                for d = 1:NC
+                    if d != c
+                        @test link[c, d] == 0
+                        @test link[d, c] == 0
+                    end
+                end
+            end
+
+            @test link' * link ≈ Matrix{ComplexF64}(I, NC, NC)
+            @test det(link) ≈ 1
+        end
+    end
+
+    @test normalized_plaquette(U) ≈ (2 * normalized_plaquette(U2) + (NC - 2)) / NC
+end
+
+@testset "SUN embedded instanton public API" begin
+    check_sun_embedded_instanton(3, (1, 2))
+    check_sun_embedded_instanton(3, (1, 3))
+    check_sun_embedded_instanton(3, (2, 3))
+    check_sun_embedded_instanton(4, (2, 4))
+    check_sun_embedded_instanton(5, (2, 5))
+    check_sun_embedded_instanton(3, (1, 3); NDW=1)
+
+    @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; block=(1, 1))
+    @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; block=(1, 4))
+    @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; NDW=-1)
+end

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -1,7 +1,6 @@
 using Gaugefields
 using Test
 using LinearAlgebra
-import Wilsonloop: make_plaq
 
 const AG = Gaugefields.AbstractGaugefields_module
 
@@ -151,62 +150,23 @@ end
     @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; NDW=-1)
 end
 
-function epsilon4(μ, ν, ρ, σ)
-    p = (μ, ν, ρ, σ)
-    length(unique(p)) == 4 || return 0
-
-    inversions = 0
-    for i = 1:4
-        for j = i+1:4
-            inversions += p[i] > p[j]
-        end
-    end
-    return iseven(inversions) ? 1 : -1
-end
-
-function plaquette_topological_charge(U)
-    Dim = 4
-    temps = [similar(U[1]), similar(U[1]), similar(U[1]), similar(U[1])]
-    F = Matrix{typeof(U[1])}(undef, Dim, Dim)
-    for μ = 1:Dim
-        for ν = 1:Dim
-            F[μ, ν] = similar(U[1])
-        end
-    end
-
-    for μ = 1:Dim
-        for ν = 1:Dim
-            if μ != ν
-                evaluate_gaugelinks!(temps[1], [make_plaq(μ, ν, Dim=Dim)], U, temps)
-                Traceless_antihermitian!(F[μ, ν], temps[1])
-            end
-        end
-    end
-
-    Q = 0.0
-    for μ = 1:Dim
-        for ν = 1:Dim
-            for ρ = 1:Dim
-                for σ = 1:Dim
-                    if μ != ν && ρ != σ
-                        Q += epsilon4(μ, ν, ρ, σ) * tr(F[μ, ν], F[ρ, σ])
-                    end
-                end
-            end
-        end
-    end
-
-    return -real(Q) / (32 * pi^2)
-end
+plaquette_topological_charge(U) = AG._plaquette_topological_charge(U)
+plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_density(U)
 
 @testset "SUN embedded instanton topological charge" begin
     L = (4, 4, 4, 4)
     cold = Initialize_Gaugefields(3, 0, L..., condition="cold")
-    @test isapprox(plaquette_topological_charge(cold), 0; atol=1e-12)
+    cold_density = plaquette_topological_charge_density(cold)
+    @test size(cold_density) == L
+    @test all(isapprox.(cold_density, 0; atol=1e-12))
+    @test isapprox(sum(cold_density), plaquette_topological_charge(cold); atol=1e-12)
 
     U2 = Oneinstanton(2, 0, L...)
+    q2 = plaquette_topological_charge_density(U2)
     Q2 = plaquette_topological_charge(U2)
     @test abs(Q2) > 1
+    @test size(q2) == L
+    @test isapprox(sum(q2), Q2; rtol=1e-12, atol=1e-12)
 
     U3 = Oneinstanton_SUN_embedded(3, L...; block=(1, 2))
     U3_alt = Oneinstanton_SUN_embedded(3, L...; block=(2, 3))
@@ -217,7 +177,14 @@ end
     @test plaquette_topological_charge(U3_alt) ≈ Q2
     @test plaquette_topological_charge(U4) ≈ Q2
     @test plaquette_topological_charge(U5) ≈ Q2
+    @test isapprox(plaquette_topological_charge_density(U3), q2; rtol=1e-12, atol=1e-12)
+    @test isapprox(plaquette_topological_charge_density(U3_alt), q2; rtol=1e-12, atol=1e-12)
+    @test isapprox(plaquette_topological_charge_density(U4), q2; rtol=1e-12, atol=1e-12)
+    @test isapprox(plaquette_topological_charge_density(U5), q2; rtol=1e-12, atol=1e-12)
 
     U3_anti = Oneinstanton_SUN_embedded(3, L...; block=(1, 2), sign=-1)
     @test plaquette_topological_charge(U3_anti) ≈ -Q2
+    q3_anti = plaquette_topological_charge_density(U3_anti)
+    @test isapprox(sum(q3_anti), -Q2; rtol=1e-12, atol=1e-12)
+    @test maximum(abs.(q3_anti .+ q2)) < 2e-5
 end

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -171,6 +171,9 @@ plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_densi
     @test topological_charge(U2) ≈ Q2
     @test_throws ArgumentError topological_charge_density(U2; method=:clover)
     @test_throws ArgumentError topological_charge(U2; method=:clover)
+    accelerator_field = Initialize_Gaugefields(3, 0, L...; condition="cold", cuda=true)
+    @test_throws ArgumentError topological_charge_density(accelerator_field)
+    @test_throws ArgumentError topological_charge(accelerator_field)
 
     U3 = Oneinstanton_SUN_embedded(3, L...; block=(1, 2))
     U3_alt = Oneinstanton_SUN_embedded(3, L...; block=(2, 3))

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -167,6 +167,10 @@ plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_densi
     @test abs(Q2) > 1
     @test size(q2) == L
     @test isapprox(sum(q2), Q2; rtol=1e-12, atol=1e-12)
+    @test topological_charge_density(U2) ≈ q2
+    @test topological_charge(U2) ≈ Q2
+    @test_throws ArgumentError topological_charge_density(U2; method=:clover)
+    @test_throws ArgumentError topological_charge(U2; method=:clover)
 
     U3 = Oneinstanton_SUN_embedded(3, L...; block=(1, 2))
     U3_alt = Oneinstanton_SUN_embedded(3, L...; block=(2, 3))
@@ -177,6 +181,7 @@ plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_densi
     @test plaquette_topological_charge(U3_alt) ≈ Q2
     @test plaquette_topological_charge(U4) ≈ Q2
     @test plaquette_topological_charge(U5) ≈ Q2
+    @test topological_charge(U3) ≈ Q2
     @test isapprox(plaquette_topological_charge_density(U3), q2; rtol=1e-12, atol=1e-12)
     @test isapprox(plaquette_topological_charge_density(U3_alt), q2; rtol=1e-12, atol=1e-12)
     @test isapprox(plaquette_topological_charge_density(U4), q2; rtol=1e-12, atol=1e-12)


### PR DESCRIPTION
## Summary

This lands the stacked implementation PRs after the docs-only design PR #116.

- Add an internal SU(2) -> SU(Nc) block embedding helper.
- Factor the existing serial SU(2) instanton link formula into a helper without enabling `Oneinstanton(3, ...)`.
- Add explicit `Oneinstanton_SUN_embedded` API for serial SU(Nc)-embedded SU(2) instantons.
- Add scalar topological charge checks and plaquette topological charge density helpers.
- Expose `topological_charge` and `topological_charge_density` for serial 4D gauge fields, with explicit rejection for unsupported field types.

## Compatibility Notes

- Existing `Oneinstanton(3, ...)` remains unsupported.
- Existing `Initialize_Gaugefields` cold/hot/GPU/MPI initialization paths are not changed.
- The existing serial SU(2) `Oneinstanton(2, ...)` formula was factored, and old-vs-new link helper comparison gave `max |old-new| = 0.0` on representative even lattices.
- GPU/MPI native support for the new instanton/topological charge paths is intentionally not claimed in this stack.

## Validation

- `julia --project=. test/runtests.jl`
- Focused SUN embedded instanton helper tests passed with 105,613 assertions.
- `git diff --check origin/master...HEAD`
- Manual old inline SU(2) instanton formula vs `_su2_instanton_link` comparison on `(4,4,4,4)`, `(6,4,4,4)`, and `(4,6,4,6)` gave zero maximum difference.
