### PR TITLE
Guard singular instanton centers

### DIFF
--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -913,6 +913,8 @@ function _su2_instanton_link(μ, ix, iy, iz, it, L; center=nothing, radius=nothi
 
     nv = ComplexF64[ix - 1 - center[1], iy - 1 - center[2], iz - 1 - center[3], it - 1 - center[4]]
     n2 = real(nv ⋅ nv)
+    isfinite(n2) || throw(ArgumentError("instanton center must contain finite coordinates"))
+    n2 > 0 || throw(ArgumentError("instanton center must not coincide with a zero-based lattice site"))
     tau = zeros(ComplexF64, 2, 2)
     for ν = 1:4
         smunu = if sign == +1

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -94,6 +94,13 @@ end
     @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; radius=0)
     @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; sign=0)
     @test_throws ArgumentError AG._su2_instanton_link(1, 1, 1, 1, 1, L; center=(1, 2, 3))
+    singular_center_error = try
+        AG._su2_instanton_link(1, 1, 1, 1, 1, L; center=(0, 0, 0, 0))
+    catch err
+        err
+    end
+    @test singular_center_error isa ArgumentError
+    @test occursin("center must not coincide", sprint(showerror, singular_center_error))
 end
 
 function normalized_plaquette(U)
@@ -148,6 +155,13 @@ end
     @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; block=(1, 1))
     @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; block=(1, 4))
     @test_throws ArgumentError Oneinstanton_SUN_embedded(3, 4, 4, 4, 4; NDW=-1)
+    singular_center_error = try
+        Oneinstanton_SUN_embedded(3, 5, 5, 5, 5)
+    catch err
+        err
+    end
+    @test singular_center_error isa ArgumentError
+    @test occursin("center must not coincide", sprint(showerror, singular_center_error))
 end
 
 plaquette_topological_charge(U) = AG._plaquette_topological_charge(U)


### PR DESCRIPTION
## Summary

Add an explicit guard for singular SU(2) instanton centers before evaluating the link matrix exponential.

- Reject non-finite instanton center coordinates.
- Reject centers that coincide with a zero-based lattice site, where `n2 == 0` would otherwise lead to `Inf`/`NaN` inside the matrix exponential.
- Cover both the private `_su2_instanton_link` helper and the public `Oneinstanton_SUN_embedded` path.

## Compatibility Notes

This does not change the successful even-lattice standard-center path. The previous behavior for singular centers was already an `ArgumentError` from the matrix exponential (`matrix contains Infs or NaNs`); this PR makes the error earlier and more descriptive.

## Validation

- `julia --project=. test/sun_embedded_instanton.jl`
- `julia --project=. test/runtests.jl`
- `git diff --check`
- Manual old inline SU(2) instanton formula vs `_su2_instanton_link` comparison on `(4,4,4,4)`, `(6,4,4,4)`, and `(4,6,4,6)` gave zero maximum difference.
