### PR TITLE
Add private clover topological charge helpers

### DIFF
--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -1011,6 +1011,67 @@ function _plaquette_topological_charge(U::Array{<:AbstractGaugefields{NC,4},1}) 
     return sum(_plaquette_topological_charge_density(U))
 end
 
+function _clover_field_strengths(U::Array{T,1}) where {NC,T<:AbstractGaugefields{NC,4}}
+    length(U) == 4 || throw(ArgumentError("U must contain four gauge-link directions"))
+
+    temps = [similar(U[1]), similar(U[1]), similar(U[1]), similar(U[1])]
+    F = Matrix{T}(undef, 4, 4)
+    for μ = 1:4
+        for ν = 1:4
+            F[μ, ν] = similar(U[1])
+        end
+    end
+
+    for μ = 1:4
+        for ν = 1:4
+            if μ != ν
+                loops = make_cloverloops(μ, ν, Dim=4)
+                evaluate_gaugelinks!(temps[1], loops, U, temps)
+                Traceless_antihermitian!(F[μ, ν], temps[1])
+            end
+        end
+    end
+    return F
+end
+
+function _clover_topological_charge_density(U::Array{T,1}) where {NC,T<:AbstractGaugefields{NC,4}}
+    F = _clover_field_strengths(U)
+    NX, NY, NZ, NT = U[1].NX, U[1].NY, U[1].NZ, U[1].NT
+    density = zeros(Float64, NX, NY, NZ, NT)
+    epsilon_terms = Tuple{Int,Int,Int,Int,Int}[]
+    for μ = 1:4
+        for ν = 1:4
+            for ρ = 1:4
+                for σ = 1:4
+                    ε = _epsilon_tensor_4d(μ, ν, ρ, σ)
+                    ε != 0 && push!(epsilon_terms, (μ, ν, ρ, σ, ε))
+                end
+            end
+        end
+    end
+
+    numofloops = 4
+    for it = 1:NT
+        for iz = 1:NZ
+            for iy = 1:NY
+                for ix = 1:NX
+                    q = zero(ComplexF64)
+                    for (μ, ν, ρ, σ, ε) in epsilon_terms
+                        q += ε * _site_trace_product(F[μ, ν], F[ρ, σ], ix, iy, iz, it)
+                    end
+                    density[ix, iy, iz, it] = -real(q) / (32 * pi^2 * numofloops^2)
+                end
+            end
+        end
+    end
+
+    return density
+end
+
+function _clover_topological_charge(U::Array{<:AbstractGaugefields{NC,4},1}) where {NC}
+    return sum(_clover_topological_charge_density(U))
+end
+
 function _check_serial_topological_charge_field(U)
     T = eltype(U)
     if !(T <: Gaugefields_4D_nowing || T <: Gaugefields_4D_wing)

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -166,6 +166,37 @@ end
 
 plaquette_topological_charge(U) = AG._plaquette_topological_charge(U)
 plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_density(U)
+clover_topological_charge(U) = AG._clover_topological_charge(U)
+clover_topological_charge_density(U) = AG._clover_topological_charge_density(U)
+
+function clover_reference_topological_charge(U)
+    temps = [similar(U[1]), similar(U[1]), similar(U[1]), similar(U[1])]
+    F = Matrix{eltype(U)}(undef, 4, 4)
+    for μ = 1:4
+        for ν = 1:4
+            F[μ, ν] = similar(U[1])
+            if μ != ν
+                evaluate_gaugelinks!(temps[1], AG.make_cloverloops(μ, ν, Dim=4), U, temps)
+                Traceless_antihermitian!(F[μ, ν], temps[1])
+            end
+        end
+    end
+
+    Q = 0.0
+    numofloops = 4
+    for μ = 1:4
+        for ν = 1:4
+            μ == ν && continue
+            for ρ = 1:4
+                for σ = 1:4
+                    ρ == σ && continue
+                    Q += AG._epsilon_tensor_4d(μ, ν, ρ, σ) * tr(F[μ, ν], F[ρ, σ]) / numofloops^2
+                end
+            end
+        end
+    end
+    return -real(Q) / (32 * pi^2)
+end
 
 @testset "SUN embedded instanton topological charge" begin
     L = (4, 4, 4, 4)
@@ -174,6 +205,11 @@ plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_densi
     @test size(cold_density) == L
     @test all(isapprox.(cold_density, 0; atol=1e-12))
     @test isapprox(sum(cold_density), plaquette_topological_charge(cold); atol=1e-12)
+    cold_clover_density = clover_topological_charge_density(cold)
+    @test size(cold_clover_density) == L
+    @test all(isapprox.(cold_clover_density, 0; atol=1e-12))
+    @test isapprox(sum(cold_clover_density), clover_topological_charge(cold); atol=1e-12)
+    @test isapprox(clover_topological_charge(cold), clover_reference_topological_charge(cold); atol=1e-12)
 
     U2 = Oneinstanton(2, 0, L...)
     q2 = plaquette_topological_charge_density(U2)
@@ -185,6 +221,11 @@ plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_densi
     @test topological_charge(U2) ≈ Q2
     @test_throws ArgumentError topological_charge_density(U2; method=:clover)
     @test_throws ArgumentError topological_charge(U2; method=:clover)
+    q2_clover = clover_topological_charge_density(U2)
+    Q2_clover = clover_topological_charge(U2)
+    @test size(q2_clover) == L
+    @test isapprox(sum(q2_clover), Q2_clover; rtol=1e-12, atol=1e-12)
+    @test isapprox(Q2_clover, clover_reference_topological_charge(U2); rtol=1e-12, atol=1e-12)
     accelerator_field = Initialize_Gaugefields(3, 0, L...; condition="cold", cuda=true)
     @test_throws ArgumentError topological_charge_density(accelerator_field)
     @test_throws ArgumentError topological_charge(accelerator_field)
@@ -203,10 +244,18 @@ plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_densi
     @test isapprox(plaquette_topological_charge_density(U3_alt), q2; rtol=1e-12, atol=1e-12)
     @test isapprox(plaquette_topological_charge_density(U4), q2; rtol=1e-12, atol=1e-12)
     @test isapprox(plaquette_topological_charge_density(U5), q2; rtol=1e-12, atol=1e-12)
+    @test clover_topological_charge(U3) ≈ Q2_clover
+    @test clover_topological_charge(U3_alt) ≈ Q2_clover
+    @test clover_topological_charge(U4) ≈ Q2_clover
+    @test clover_topological_charge(U5) ≈ Q2_clover
+    @test isapprox(clover_topological_charge_density(U3), q2_clover; rtol=1e-12, atol=1e-12)
+    @test isapprox(clover_topological_charge_density(U3_alt), q2_clover; rtol=1e-12, atol=1e-12)
 
     U3_anti = Oneinstanton_SUN_embedded(3, L...; block=(1, 2), sign=-1)
     @test plaquette_topological_charge(U3_anti) ≈ -Q2
     q3_anti = plaquette_topological_charge_density(U3_anti)
     @test isapprox(sum(q3_anti), -Q2; rtol=1e-12, atol=1e-12)
     @test maximum(abs.(q3_anti .+ q2)) < 2e-5
+    q3_anti_clover = clover_topological_charge_density(U3_anti)
+    @test isapprox(sum(q3_anti_clover), -Q2_clover; rtol=1e-12, atol=1e-12)
 end


### PR DESCRIPTION
## Summary

- add private `_clover_field_strengths`, `_clover_topological_charge_density`, and `_clover_topological_charge` helpers
- keep public `topological_charge_density(...; method=:clover)` and `topological_charge(...; method=:clover)` behavior unchanged for this PR
- extend focused SU(Nc)-embedded instanton tests to cover clover density, scalar normalization, block independence, and sign behavior

## Behavior impact

This PR does not route the public `method=:clover` keyword yet. Existing public `method=:plaquette` behavior is unchanged, and unsupported public `method=:clover` calls still throw `ArgumentError`.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `julia --project=. test/sun_embedded_instanton.jl`
- `julia --project=. test/runtests.jl`

## Medium/longer-term plan

1. Merge this private-helper PR after review.
2. Add a small public-routing PR for `topological_charge_density(U; method=:clover)` and `topological_charge(U; method=:clover)` using these helpers.
3. Add user-facing docs/examples comparing `method=:plaquette` and `method=:clover` and preserving the `sum(q) == Q` contract.
4. Later, consider improved/rectangle methods and visualization-facing density conventions separately.

GPU/MPI measurement support remains out of scope for this clover-density sequence.