### PR TITLE
Route clover topological charge methods

### DIFF
--- a/docs/codex/su3_embedded_instanton/clover_topological_charge_design.md
+++ b/docs/codex/su3_embedded_instanton/clover_topological_charge_design.md
@@ -35,7 +35,9 @@ Q = topological_charge(U; method=:plaquette)
 ```
 
 with `Q == sum(q)` by construction. The API currently accepts only
-`method=:plaquette`; `method=:clover` throws a clear `ArgumentError`.
+`method=:plaquette` on `master` at the time this note was written; the next
+implementation step is to route `method=:clover` through the private clover
+helpers.
 
 ## Usage example for the embedded instanton
 
@@ -193,8 +195,7 @@ julia --project=. test/runtests.jl
 
 1. This docs-only PR: document embedded-instanton usage and the clover-density
    design.
-2. Add private clover field-strength and density helpers, leaving the public
-   `method=:clover` error in place if useful for review size.
+2. Add private clover field-strength and density helpers.
 3. Route `topological_charge_density(U; method=:clover)` and
    `topological_charge(U; method=:clover)` to the clover helpers, with the
    focused tests above.

--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -1085,24 +1085,36 @@ end
 
 Return the site-wise topological charge density `q(x)` for a 4D gauge field.
 The scalar topological charge is `sum(topological_charge_density(U))`.
+Supported methods are `:plaquette` and `:clover`.
 """
 function topological_charge_density(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:plaquette) where {NC,Dim}
     Dim == 4 || throw(ArgumentError("topological_charge_density only supports 4D gauge fields"))
     _check_serial_topological_charge_field(U)
-    method == :plaquette || throw(ArgumentError("only method=:plaquette is supported"))
-    return _plaquette_topological_charge_density(U)
+    if method == :plaquette
+        return _plaquette_topological_charge_density(U)
+    elseif method == :clover
+        return _clover_topological_charge_density(U)
+    else
+        throw(ArgumentError("supported topological_charge_density methods are :plaquette and :clover"))
+    end
 end
 
 """
     topological_charge(U; method=:plaquette)
 
 Return the scalar topological charge `Q` for a 4D gauge field.
+Supported methods are `:plaquette` and `:clover`.
 """
 function topological_charge(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:plaquette) where {NC,Dim}
     Dim == 4 || throw(ArgumentError("topological_charge only supports 4D gauge fields"))
     _check_serial_topological_charge_field(U)
-    method == :plaquette || throw(ArgumentError("only method=:plaquette is supported"))
-    return _plaquette_topological_charge(U)
+    if method == :plaquette
+        return _plaquette_topological_charge(U)
+    elseif method == :clover
+        return _clover_topological_charge(U)
+    else
+        throw(ArgumentError("supported topological_charge methods are :plaquette and :clover"))
+    end
 end
 
 function Oneinstanton_SUN_embedded(

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -219,13 +219,15 @@ end
     @test isapprox(sum(q2), Q2; rtol=1e-12, atol=1e-12)
     @test topological_charge_density(U2) ≈ q2
     @test topological_charge(U2) ≈ Q2
-    @test_throws ArgumentError topological_charge_density(U2; method=:clover)
-    @test_throws ArgumentError topological_charge(U2; method=:clover)
     q2_clover = clover_topological_charge_density(U2)
     Q2_clover = clover_topological_charge(U2)
     @test size(q2_clover) == L
     @test isapprox(sum(q2_clover), Q2_clover; rtol=1e-12, atol=1e-12)
     @test isapprox(Q2_clover, clover_reference_topological_charge(U2); rtol=1e-12, atol=1e-12)
+    @test topological_charge_density(U2; method=:clover) ≈ q2_clover
+    @test topological_charge(U2; method=:clover) ≈ Q2_clover
+    @test_throws ArgumentError topological_charge_density(U2; method=:rect)
+    @test_throws ArgumentError topological_charge(U2; method=:rect)
     accelerator_field = Initialize_Gaugefields(3, 0, L...; condition="cold", cuda=true)
     @test_throws ArgumentError topological_charge_density(accelerator_field)
     @test_throws ArgumentError topological_charge(accelerator_field)
@@ -250,6 +252,8 @@ end
     @test clover_topological_charge(U5) ≈ Q2_clover
     @test isapprox(clover_topological_charge_density(U3), q2_clover; rtol=1e-12, atol=1e-12)
     @test isapprox(clover_topological_charge_density(U3_alt), q2_clover; rtol=1e-12, atol=1e-12)
+    @test topological_charge(U3; method=:clover) ≈ Q2_clover
+    @test isapprox(topological_charge_density(U3; method=:clover), q2_clover; rtol=1e-12, atol=1e-12)
 
     U3_anti = Oneinstanton_SUN_embedded(3, L...; block=(1, 2), sign=-1)
     @test plaquette_topological_charge(U3_anti) ≈ -Q2


### PR DESCRIPTION
## Summary

- route `topological_charge_density(U; method=:clover)` to the private clover density helper
- route `topological_charge(U; method=:clover)` to the private clover scalar helper
- keep the default `method=:plaquette` behavior unchanged
- update focused tests and the clover design note to reflect the new routing step

## Behavior impact

This enables the public `method=:clover` keyword for serial 4D gauge fields. The existing default `method=:plaquette` path is unchanged. Unsupported methods such as `:rect` still throw `ArgumentError`.

GPU/MPI measurement support remains outside this sequence; the existing serial 4D guard is unchanged.

## Validation

- `git diff --check`
- `git diff --cached --check`
- `julia --project=. test/sun_embedded_instanton.jl`
- `julia --project=. test/runtests.jl`

## Medium/longer-term plan

1. Merge this public-routing PR after review and CI.
2. Add user-facing docs/examples for `method=:plaquette` vs `method=:clover`, including `sum(q) == Q`.
3. Consider improved/rectangle density methods separately, with the same scalar/density normalization contract.
4. Keep GPU/MPI topological-charge measurements as a later design topic, not part of this public routing PR.