### PR TITLE
Document clover topological charge usage

### DIFF
--- a/docs/codex/su3_embedded_instanton/clover_topological_charge_design.md
+++ b/docs/codex/su3_embedded_instanton/clover_topological_charge_design.md
@@ -35,9 +35,7 @@ Q = topological_charge(U; method=:plaquette)
 ```
 
 with `Q == sum(q)` by construction. The API currently accepts only
-`method=:plaquette` on `master` at the time this note was written; the next
-implementation step is to route `method=:clover` through the private clover
-helpers.
+`method=:plaquette` and `method=:clover` for serial 4D gauge fields.
 
 ## Usage example for the embedded instanton
 
@@ -200,3 +198,4 @@ julia --project=. test/runtests.jl
    `topological_charge(U; method=:clover)` to the clover helpers, with the
    focused tests above.
 4. Revisit examples or manual docs after the implementation is merged.
+5. Consider improved or rectangle density methods separately.

--- a/docs/src/measurements.md
+++ b/docs/src/measurements.md
@@ -207,6 +207,38 @@ test()
 We show the code to calculate the topological charge. 
 We show three definitions. 
 
+The public API returns either the scalar topological charge `Q` or the
+site-wise topological charge density `q(x)`. The scalar result is defined as
+the sum of the density with the same method and normalization.
+
+```julia
+using Gaugefields
+
+NX = 4
+NY = 4
+NZ = 4
+NT = 4
+NC = 3
+
+U = Oneinstanton_SUN_embedded(NC, NX, NY, NZ, NT; block=(1, 2))
+
+q_plaq = topological_charge_density(U; method=:plaquette)
+Q_plaq = topological_charge(U; method=:plaquette)
+
+q_clover = topological_charge_density(U; method=:clover)
+Q_clover = topological_charge(U; method=:clover)
+
+@assert size(q_plaq) == (NX, NY, NZ, NT)
+@assert size(q_clover) == (NX, NY, NZ, NT)
+@assert isapprox(sum(q_plaq), Q_plaq; rtol=1e-12, atol=1e-12)
+@assert isapprox(sum(q_clover), Q_clover; rtol=1e-12, atol=1e-12)
+```
+
+`method=:plaquette` is the default. `method=:clover` uses the four-loop clover
+definition for each ordered direction pair. These public helpers currently
+support serial 4D gauge fields. MPI, accelerator fields, and improved or
+rectangle definitions are separate topics.
+
 ```julia
 using Gaugefields
 using Wilsonloop


### PR DESCRIPTION
## Summary

- add a short public API example for `topological_charge_density` and `topological_charge`
- show both `method=:plaquette` and `method=:clover`
- document the `sum(q) == Q` contract and current serial 4D scope
- update the clover design note to reflect that public clover routing has landed

## Behavior impact

Docs-only. No package code changes.

## Validation

- `git diff --check`
- `git diff --cached --check`
- ran the new docs snippet with `julia --project=.`

## Medium/longer-term plan

1. Merge this docs/examples PR after review and docs CI.
2. Consider improved or rectangle topological-charge density methods as a separate design and implementation sequence.
3. Keep GPU/MPI topological-charge measurement support as a later design topic.