### PR TITLE
Document topological charge method roadmap

### DIFF
--- a/docs/codex/su3_embedded_instanton/clover_topological_charge_design.md
+++ b/docs/codex/su3_embedded_instanton/clover_topological_charge_design.md
@@ -1,8 +1,8 @@
 # SU(Nc)-Embedded Instanton Usage and Clover Density Design
 
-This note is a docs-only follow-up to the SU(Nc)-embedded SU(2) instanton work.
-It records the next small step before implementing `method=:clover` support for
-`topological_charge_density` and `topological_charge`.
+This note records the design used for the SU(Nc)-embedded SU(2) instanton
+usage examples and for `method=:clover` support in `topological_charge_density`
+and `topological_charge`.
 
 This PR should not change package behavior. In particular, it should not enable
 `Oneinstanton(3, ...)`, should not alter `Oneinstanton_SUN_embedded`, and should
@@ -163,8 +163,7 @@ slicing, interpolation, color scaling, or smoothing.
 
 ## Tests for the implementation PR
 
-The docs-only PR does not need runtime tests. The implementation PR that enables
-`method=:clover` should add focused tests:
+The implementation PR that enables `method=:clover` should add focused tests:
 
 - cold serial 4D fields have zero clover density and zero scalar charge,
 - `sum(topological_charge_density(U; method=:clover))` matches
@@ -191,11 +190,11 @@ julia --project=. test/runtests.jl
 
 ## Suggested next PRs
 
-1. This docs-only PR: document embedded-instanton usage and the clover-density
-   design.
-2. Add private clover field-strength and density helpers.
-3. Route `topological_charge_density(U; method=:clover)` and
+1. Done: document embedded-instanton usage and the clover-density design.
+2. Done: add private clover field-strength and density helpers.
+3. Done: route `topological_charge_density(U; method=:clover)` and
    `topological_charge(U; method=:clover)` to the clover helpers, with the
    focused tests above.
-4. Revisit examples or manual docs after the implementation is merged.
-5. Consider improved or rectangle density methods separately.
+4. Done: add a short manual example for public plaquette and clover usage.
+5. Next: consider improved or rectangle density methods separately. See
+   `topological_charge_method_roadmap.md`.

--- a/docs/codex/su3_embedded_instanton/design.md
+++ b/docs/codex/su3_embedded_instanton/design.md
@@ -248,9 +248,12 @@ Tests:
 - A small fixture confirms that the visualized density sums back to the scalar
   `Q` used by Gaugefields.jl.
 
-Follow-up note: `clover_topological_charge_design.md` records the next
-docs-only step for `Oneinstanton_SUN_embedded` usage examples and the
-`topological_charge_density(U; method=:clover)` design.
+Follow-up notes:
+
+- `clover_topological_charge_design.md` records the implemented clover density
+  design and the embedded-instanton usage examples.
+- `topological_charge_method_roadmap.md` records the next measurement-method
+  candidates, including rectangle/improved density and GPU/MPI design questions.
 
 ## Test placement and commands
 
@@ -268,10 +271,11 @@ public API explicitly supports those paths.
 
 ## Branch and PR workflow
 
-Do not push directly to `main`.
+Do not push directly to the default branch. This repository currently uses
+`master`.
 
 Use one local branch and one remote branch per PR. After a PR is merged, update
-local `main` and create the next PR branch from the updated `main`.
+local `master` and create the next PR branch from the updated `master`.
 
 Suggested branch sequence:
 
@@ -287,7 +291,7 @@ Suggested branch sequence:
 Normal flow:
 
 ```sh
-git switch main
+git switch master
 git pull --ff-only
 git switch -c codex/sun-embedded-instanton-design
 # edit, test, commit
@@ -297,7 +301,7 @@ git push -u origin codex/sun-embedded-instanton-design
 After PR-1 is merged:
 
 ```sh
-git switch main
+git switch master
 git pull --ff-only
 git switch -c codex/sun-embedded-instanton-helper
 ```
@@ -311,5 +315,5 @@ git switch -c codex/sun-embedded-instanton-helper
 ```
 
 In stacked mode, keep the PR description clear about the dependency on the
-previous PR. Rebase the later branch onto updated `main` after the earlier PR is
-merged.
+previous PR. Rebase the later branch onto updated `master` after the earlier PR
+is merged.

--- a/docs/codex/su3_embedded_instanton/topological_charge_method_roadmap.md
+++ b/docs/codex/su3_embedded_instanton/topological_charge_method_roadmap.md
@@ -1,0 +1,112 @@
+# Topological Charge Method Roadmap
+
+This note is a docs-only checkpoint after the SU(Nc)-embedded instanton,
+plaquette density, and clover density PRs. It keeps the next measurement work
+separate from the already-merged public behavior.
+
+## Current supported surface
+
+For serial 4D gauge fields, the public API is:
+
+```julia
+q = topological_charge_density(U; method=:plaquette)
+Q = topological_charge(U; method=:plaquette)
+
+q = topological_charge_density(U; method=:clover)
+Q = topological_charge(U; method=:clover)
+```
+
+`method=:plaquette` remains the default. For each supported method, the scalar
+charge is defined as the site-wise sum:
+
+```julia
+topological_charge(U; method=method) ==
+    sum(topological_charge_density(U; method=method))
+```
+
+Unsupported methods should keep throwing `ArgumentError` until their density
+and scalar conventions are pinned by tests.
+
+## Next measurement candidates
+
+The existing sample measurement code contains an improved scalar convention:
+
+```julia
+Qrect = 2 * calc_Q(UmunuTA, numofloops, U)
+Qimproved = (5 / 3) * Qclover - (1 / 12) * Qrect
+```
+
+The corresponding public density work should preserve the same normalization:
+
+```julia
+q_improved(x) = (5 / 3) * q_clover(x) - (1 / 12) * q_rect(x)
+sum(q_improved) == Qimproved
+```
+
+The rectangle density is the risky piece. Before exposing a public
+`method=:rect` or `method=:improved`, a private helper should first reproduce
+the scalar sample result exactly on small serial 4D fields.
+
+## Suggested small PR sequence
+
+1. Add a private rectangle-density helper and focused tests against the existing
+   sample scalar formula. Do not expose a public method yet.
+2. Add a private improved-density helper as a linear combination of the clover
+   and rectangle densities. Test `sum(q_improved) == Qimproved`.
+3. Route `method=:improved` publicly only after the private helper is pinned.
+   Keep `method=:rect` private unless there is a clear user-facing reason to
+   expose it.
+4. Add short manual docs for `method=:improved` after the API is public.
+5. Treat GPU/MPI support as a separate design PR before implementation.
+
+## Tests for rectangle and improved density
+
+Use focused serial 4D tests before touching the full suite:
+
+- cold fields have zero rectangle and improved density,
+- `sum(q_rect)` matches the sample scalar `Qrect`,
+- `sum(q_improved)` matches the sample scalar `Qimproved`,
+- SU(2) instantons and SU(Nc)-embedded instantons agree for the same method,
+- changing `block` does not change scalar charge,
+- `sign=-1` flips scalar charge,
+- existing plaquette and clover tests remain unchanged,
+- unsupported public methods still throw until deliberately enabled.
+
+Before merging an implementation PR, run:
+
+```sh
+julia --project=. test/sun_embedded_instanton.jl
+julia --project=. test/runtests.jl
+```
+
+## GPU and MPI notes
+
+The instanton initialization path and the topological-charge measurement path
+should be judged separately. Even if an initialized field can exist on an
+accelerator or MPI-backed storage type, the current density implementation
+builds temporary gauge fields, evaluates loop operators, and reads site-wise
+matrix elements into a host `Array`.
+
+That means GPU and MPI support should not be inferred from initialization
+support. A later design should decide:
+
+- whether density is computed locally and then gathered,
+- how boundary/halo data is represented in site-wise `q(x)`,
+- whether the public return type should remain a host `Array`,
+- how to test MPI reductions of scalar `Q` independently from local density,
+- whether accelerator fields need a host fallback or native kernels.
+
+Until that design exists, serial 4D support is the stable public contract for
+`topological_charge_density` and `topological_charge`.
+
+## Remaining risks
+
+- Rectangle-loop normalization is easy to get wrong because the sample scalar
+  includes both `numofloops` and an extra factor of `2`.
+- The density location convention should remain "indexed by the site where the
+  loop set is evaluated"; visualization should not reinterpret this inside
+  Gaugefields.jl.
+- Coarse instanton tests should check method consistency and sign/block
+  invariants, not claim continuum integer charge too strongly.
+- Public methods should only be enabled after both scalar and density tests are
+  in place.


### PR DESCRIPTION
## Summary
- document the post-clover roadmap for rectangle/improved topological-charge density
- clarify that GPU/MPI measurement support needs a separate design from instanton initialization
- refresh the earlier design docs now that clover support and manual usage docs have landed

## Tests
- git diff --check
- git diff --cached --check
- julia --project=. test/sun_embedded_instanton.jl