### PR TITLE
Add private rectangle topological charge helper

### DIFF
--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -1072,6 +1072,83 @@ function _clover_topological_charge(U::Array{<:AbstractGaugefields{NC,4},1}) whe
     return sum(_clover_topological_charge_density(U))
 end
 
+function _rectangle_loops(μ, ν; Dim=4)
+    loops = Wilsonline{Dim}[]
+
+    push!(loops, Wilsonline([(μ, 2), (ν, 1), (μ, -2), (ν, -1)]))
+    push!(loops, Wilsonline([(ν, 1), (μ, -2), (ν, -1), (μ, 2)]))
+    push!(loops, Wilsonline([(ν, -1), (μ, 2), (ν, 1), (μ, -2)]))
+    push!(loops, Wilsonline([(μ, -2), (ν, -1), (μ, 2), (ν, 1)]))
+
+    push!(loops, Wilsonline([(μ, 1), (ν, 2), (μ, -1), (ν, -2)]))
+    push!(loops, Wilsonline([(ν, 2), (μ, -1), (ν, -2), (μ, 1)]))
+    push!(loops, Wilsonline([(ν, -2), (μ, 1), (ν, 2), (μ, -1)]))
+    push!(loops, Wilsonline([(μ, -1), (ν, -2), (μ, 1), (ν, 2)]))
+
+    return loops
+end
+
+function _rectangle_field_strengths(U::Array{T,1}) where {NC,T<:AbstractGaugefields{NC,4}}
+    length(U) == 4 || throw(ArgumentError("U must contain four gauge-link directions"))
+
+    temps = [similar(U[1]), similar(U[1]), similar(U[1]), similar(U[1])]
+    F = Matrix{T}(undef, 4, 4)
+    for μ = 1:4
+        for ν = 1:4
+            F[μ, ν] = similar(U[1])
+        end
+    end
+
+    for μ = 1:4
+        for ν = 1:4
+            if μ != ν
+                evaluate_gaugelinks!(temps[1], _rectangle_loops(μ, ν, Dim=4), U, temps)
+                Traceless_antihermitian!(F[μ, ν], temps[1])
+            end
+        end
+    end
+    return F
+end
+
+function _rectangle_topological_charge_density(U::Array{T,1}) where {NC,T<:AbstractGaugefields{NC,4}}
+    F = _rectangle_field_strengths(U)
+    NX, NY, NZ, NT = U[1].NX, U[1].NY, U[1].NZ, U[1].NT
+    density = zeros(Float64, NX, NY, NZ, NT)
+    epsilon_terms = Tuple{Int,Int,Int,Int,Int}[]
+    for μ = 1:4
+        for ν = 1:4
+            for ρ = 1:4
+                for σ = 1:4
+                    ε = _epsilon_tensor_4d(μ, ν, ρ, σ)
+                    ε != 0 && push!(epsilon_terms, (μ, ν, ρ, σ, ε))
+                end
+            end
+        end
+    end
+
+    numofloops = 8
+    rect_factor = 2
+    for it = 1:NT
+        for iz = 1:NZ
+            for iy = 1:NY
+                for ix = 1:NX
+                    q = zero(ComplexF64)
+                    for (μ, ν, ρ, σ, ε) in epsilon_terms
+                        q += ε * _site_trace_product(F[μ, ν], F[ρ, σ], ix, iy, iz, it)
+                    end
+                    density[ix, iy, iz, it] = -rect_factor * real(q) / (32 * pi^2 * numofloops^2)
+                end
+            end
+        end
+    end
+
+    return density
+end
+
+function _rectangle_topological_charge(U::Array{<:AbstractGaugefields{NC,4},1}) where {NC}
+    return sum(_rectangle_topological_charge_density(U))
+end
+
 function _check_serial_topological_charge_field(U)
     T = eltype(U)
     if !(T <: Gaugefields_4D_nowing || T <: Gaugefields_4D_wing)

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -1,6 +1,7 @@
 using Gaugefields
 using Test
 using LinearAlgebra
+using Wilsonloop: Wilsonline
 
 const AG = Gaugefields.AbstractGaugefields_module
 
@@ -168,6 +169,8 @@ plaquette_topological_charge(U) = AG._plaquette_topological_charge(U)
 plaquette_topological_charge_density(U) = AG._plaquette_topological_charge_density(U)
 clover_topological_charge(U) = AG._clover_topological_charge(U)
 clover_topological_charge_density(U) = AG._clover_topological_charge_density(U)
+rectangle_topological_charge(U) = AG._rectangle_topological_charge(U)
+rectangle_topological_charge_density(U) = AG._rectangle_topological_charge_density(U)
 
 function clover_reference_topological_charge(U)
     temps = [similar(U[1]), similar(U[1]), similar(U[1]), similar(U[1])]
@@ -198,6 +201,51 @@ function clover_reference_topological_charge(U)
     return -real(Q) / (32 * pi^2)
 end
 
+function rectangle_reference_loops(μ, ν; Dim=4)
+    loops = Wilsonline{Dim}[]
+
+    push!(loops, Wilsonline([(μ, 2), (ν, 1), (μ, -2), (ν, -1)]))
+    push!(loops, Wilsonline([(ν, 1), (μ, -2), (ν, -1), (μ, 2)]))
+    push!(loops, Wilsonline([(ν, -1), (μ, 2), (ν, 1), (μ, -2)]))
+    push!(loops, Wilsonline([(μ, -2), (ν, -1), (μ, 2), (ν, 1)]))
+
+    push!(loops, Wilsonline([(μ, 1), (ν, 2), (μ, -1), (ν, -2)]))
+    push!(loops, Wilsonline([(ν, 2), (μ, -1), (ν, -2), (μ, 1)]))
+    push!(loops, Wilsonline([(ν, -2), (μ, 1), (ν, 2), (μ, -1)]))
+    push!(loops, Wilsonline([(μ, -1), (ν, -2), (μ, 1), (ν, 2)]))
+
+    return loops
+end
+
+function rectangle_reference_topological_charge(U)
+    temps = [similar(U[1]), similar(U[1]), similar(U[1]), similar(U[1])]
+    F = Matrix{eltype(U)}(undef, 4, 4)
+    for μ = 1:4
+        for ν = 1:4
+            F[μ, ν] = similar(U[1])
+            if μ != ν
+                evaluate_gaugelinks!(temps[1], rectangle_reference_loops(μ, ν, Dim=4), U, temps)
+                Traceless_antihermitian!(F[μ, ν], temps[1])
+            end
+        end
+    end
+
+    Q = 0.0
+    numofloops = 8
+    for μ = 1:4
+        for ν = 1:4
+            μ == ν && continue
+            for ρ = 1:4
+                for σ = 1:4
+                    ρ == σ && continue
+                    Q += AG._epsilon_tensor_4d(μ, ν, ρ, σ) * tr(F[μ, ν], F[ρ, σ]) / numofloops^2
+                end
+            end
+        end
+    end
+    return 2 * (-real(Q) / (32 * pi^2))
+end
+
 @testset "SUN embedded instanton topological charge" begin
     L = (4, 4, 4, 4)
     cold = Initialize_Gaugefields(3, 0, L..., condition="cold")
@@ -210,6 +258,11 @@ end
     @test all(isapprox.(cold_clover_density, 0; atol=1e-12))
     @test isapprox(sum(cold_clover_density), clover_topological_charge(cold); atol=1e-12)
     @test isapprox(clover_topological_charge(cold), clover_reference_topological_charge(cold); atol=1e-12)
+    cold_rectangle_density = rectangle_topological_charge_density(cold)
+    @test size(cold_rectangle_density) == L
+    @test all(isapprox.(cold_rectangle_density, 0; atol=1e-12))
+    @test isapprox(sum(cold_rectangle_density), rectangle_topological_charge(cold); atol=1e-12)
+    @test isapprox(rectangle_topological_charge(cold), rectangle_reference_topological_charge(cold); atol=1e-12)
 
     U2 = Oneinstanton(2, 0, L...)
     q2 = plaquette_topological_charge_density(U2)
@@ -226,6 +279,11 @@ end
     @test isapprox(Q2_clover, clover_reference_topological_charge(U2); rtol=1e-12, atol=1e-12)
     @test topological_charge_density(U2; method=:clover) ≈ q2_clover
     @test topological_charge(U2; method=:clover) ≈ Q2_clover
+    q2_rectangle = rectangle_topological_charge_density(U2)
+    Q2_rectangle = rectangle_topological_charge(U2)
+    @test size(q2_rectangle) == L
+    @test isapprox(sum(q2_rectangle), Q2_rectangle; rtol=1e-12, atol=1e-12)
+    @test isapprox(Q2_rectangle, rectangle_reference_topological_charge(U2); rtol=1e-12, atol=1e-12)
     @test_throws ArgumentError topological_charge_density(U2; method=:rect)
     @test_throws ArgumentError topological_charge(U2; method=:rect)
     accelerator_field = Initialize_Gaugefields(3, 0, L...; condition="cold", cuda=true)
@@ -254,6 +312,12 @@ end
     @test isapprox(clover_topological_charge_density(U3_alt), q2_clover; rtol=1e-12, atol=1e-12)
     @test topological_charge(U3; method=:clover) ≈ Q2_clover
     @test isapprox(topological_charge_density(U3; method=:clover), q2_clover; rtol=1e-12, atol=1e-12)
+    @test rectangle_topological_charge(U3) ≈ Q2_rectangle
+    @test rectangle_topological_charge(U3_alt) ≈ Q2_rectangle
+    @test rectangle_topological_charge(U4) ≈ Q2_rectangle
+    @test rectangle_topological_charge(U5) ≈ Q2_rectangle
+    @test isapprox(rectangle_topological_charge_density(U3), q2_rectangle; rtol=1e-12, atol=1e-12)
+    @test isapprox(rectangle_topological_charge_density(U3_alt), q2_rectangle; rtol=1e-12, atol=1e-12)
 
     U3_anti = Oneinstanton_SUN_embedded(3, L...; block=(1, 2), sign=-1)
     @test plaquette_topological_charge(U3_anti) ≈ -Q2
@@ -262,4 +326,6 @@ end
     @test maximum(abs.(q3_anti .+ q2)) < 2e-5
     q3_anti_clover = clover_topological_charge_density(U3_anti)
     @test isapprox(sum(q3_anti_clover), -Q2_clover; rtol=1e-12, atol=1e-12)
+    q3_anti_rectangle = rectangle_topological_charge_density(U3_anti)
+    @test isapprox(sum(q3_anti_rectangle), -Q2_rectangle; rtol=1e-12, atol=1e-12)
 end


### PR DESCRIPTION
## Summary
- add private rectangle loop, field-strength, density, and scalar topological-charge helpers
- match the existing sample convention Qrect = 2 * calc_Q(..., numofloops=8)
- keep method=:rect unsupported in the public API for now

## Tests
- git diff --check
- git diff --cached --check
- julia --project=. test/sun_embedded_instanton.jl
- julia --project=. test/runtests.jl