### PR TITLE
Expose improved topological charge method

### DIFF
--- a/src/AbstractGaugefields.jl
+++ b/src/AbstractGaugefields.jl
@@ -1172,7 +1172,7 @@ end
 
 Return the site-wise topological charge density `q(x)` for a 4D gauge field.
 The scalar topological charge is `sum(topological_charge_density(U))`.
-Supported methods are `:plaquette` and `:clover`.
+Supported methods are `:plaquette`, `:clover`, and `:improved`.
 """
 function topological_charge_density(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:plaquette) where {NC,Dim}
     Dim == 4 || throw(ArgumentError("topological_charge_density only supports 4D gauge fields"))
@@ -1181,8 +1181,10 @@ function topological_charge_density(U::Array{<:AbstractGaugefields{NC,Dim},1}; m
         return _plaquette_topological_charge_density(U)
     elseif method == :clover
         return _clover_topological_charge_density(U)
+    elseif method == :improved
+        return _improved_topological_charge_density(U)
     else
-        throw(ArgumentError("supported topological_charge_density methods are :plaquette and :clover"))
+        throw(ArgumentError("supported topological_charge_density methods are :plaquette, :clover, and :improved"))
     end
 end
 
@@ -1190,7 +1192,7 @@ end
     topological_charge(U; method=:plaquette)
 
 Return the scalar topological charge `Q` for a 4D gauge field.
-Supported methods are `:plaquette` and `:clover`.
+Supported methods are `:plaquette`, `:clover`, and `:improved`.
 """
 function topological_charge(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:plaquette) where {NC,Dim}
     Dim == 4 || throw(ArgumentError("topological_charge only supports 4D gauge fields"))
@@ -1199,8 +1201,10 @@ function topological_charge(U::Array{<:AbstractGaugefields{NC,Dim},1}; method=:p
         return _plaquette_topological_charge(U)
     elseif method == :clover
         return _clover_topological_charge(U)
+    elseif method == :improved
+        return _improved_topological_charge(U)
     else
-        throw(ArgumentError("supported topological_charge methods are :plaquette and :clover"))
+        throw(ArgumentError("supported topological_charge methods are :plaquette, :clover, and :improved"))
     end
 end
 

--- a/test/sun_embedded_instanton.jl
+++ b/test/sun_embedded_instanton.jl
@@ -303,10 +303,10 @@ end
     @test isapprox(sum(q2_improved), Q2_improved; rtol=1e-12, atol=1e-12)
     @test isapprox(q2_improved, (5 / 3) .* q2_clover .- (1 / 12) .* q2_rectangle; rtol=1e-12, atol=1e-12)
     @test isapprox(Q2_improved, improved_reference_topological_charge(U2); rtol=1e-12, atol=1e-12)
+    @test topological_charge_density(U2; method=:improved) ≈ q2_improved
+    @test topological_charge(U2; method=:improved) ≈ Q2_improved
     @test_throws ArgumentError topological_charge_density(U2; method=:rect)
     @test_throws ArgumentError topological_charge(U2; method=:rect)
-    @test_throws ArgumentError topological_charge_density(U2; method=:improved)
-    @test_throws ArgumentError topological_charge(U2; method=:improved)
     accelerator_field = Initialize_Gaugefields(3, 0, L...; condition="cold", cuda=true)
     @test_throws ArgumentError topological_charge_density(accelerator_field)
     @test_throws ArgumentError topological_charge(accelerator_field)
@@ -345,6 +345,8 @@ end
     @test improved_topological_charge(U5) ≈ Q2_improved
     @test isapprox(improved_topological_charge_density(U3), q2_improved; rtol=1e-12, atol=1e-12)
     @test isapprox(improved_topological_charge_density(U3_alt), q2_improved; rtol=1e-12, atol=1e-12)
+    @test topological_charge(U3; method=:improved) ≈ Q2_improved
+    @test isapprox(topological_charge_density(U3; method=:improved), q2_improved; rtol=1e-12, atol=1e-12)
 
     U3_anti = Oneinstanton_SUN_embedded(3, L...; block=(1, 2), sign=-1)
     @test plaquette_topological_charge(U3_anti) ≈ -Q2


### PR DESCRIPTION
Summary:
- route public topological_charge_density/topological_charge method=:improved to the private improved helpers
- update docstrings and focused tests for SU(2) and SU(Nc)-embedded instantons
- keep the default method=:plaquette and method=:rect unsupported

Tests:
- git diff --check
- git diff --cached --check
- /Users/akio/.juliaup/bin/julia --project=. test/sun_embedded_instanton.jl
- /Users/akio/.juliaup/bin/julia --project=. test/runtests.jl